### PR TITLE
ci: standardise workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,24 +12,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: https://registry.npmjs.org
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build
-        run: bun run build
+      - name: Download release tarball
+        run: gh release download "${{ github.event.release.tag_name }}" --pattern "*.tgz" --dir .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish *.tgz --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Align test.yml, build.yml, release.yml formatting across all MCP repos
- Rewrite publish.yml: download release tarball instead of rebuilding from source
- Ensures npm publishes the exact artifact from the GitHub Release — no second build