### PR TITLE
fix: point inspect script at source instead of dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "dev": "bun --watch src/main.ts",
-    "inspect": "DANGEROUSLY_OMIT_AUTH=true mcp-inspector bun dist/main.js",
+    "inspect": "DANGEROUSLY_OMIT_AUTH=true mcp-inspector bun src/main.ts",
     "build": "bun build src/main.ts --outfile dist/main.js --target bun",
     "typecheck": "tsc -p tsconfig.check.json",
     "test": "bun test",


### PR DESCRIPTION
## Summary
- Changes inspect script from bun dist/main.js to bun src/main.ts
- Bun runs TypeScript directly — no build step needed for local inspection

## Test plan
- [ ] bun run inspect launches the MCP inspector successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)