### PR TITLE
fix: read version from package.json instead of hardcoding

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ManagedRuntime } from "effect";
+import pkg from "../../package.json";
 import type { TflDisambiguationError, TflError } from "../domain/errors.ts";
 import type { TflClient } from "../domain/TflClient.ts";
 import { registerAccidentTools } from "./tools/accident.ts";
@@ -21,7 +22,7 @@ export const createMcpServer = (
 ): McpServer => {
   const server = new McpServer({
     name: "tfl-mcp-server",
-    version: "1.0.8",
+    version: pkg.version,
   });
 
   registerAccidentTools(server, runtime);


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `version: "1.0.8"` in `src/mcp/server.ts` with a dynamic import of `pkg.version` from `package.json`
- The server advertised version was stale (1.0.8) while the actual package version is 1.1.5; this ensures they stay in sync automatically on every release

## Test plan

- [ ] `bun run lint` — passes with no issues
- [ ] `bun run typecheck` — passes with no type errors
- [ ] `bun test` — all 19 tests pass
- [ ] Verify at runtime: the MCP server handshake reports version `1.1.5` (matching `package.json`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)