### PR TITLE
refactor: deduplicate ArrivalPrediction type and formatArrival helper

### DIFF
--- a/src/mcp/arrivals.ts
+++ b/src/mcp/arrivals.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared ArrivalPrediction type and formatter used by line, stop-point, and mode tools.
+ *
+ * This is the superset of all fields returned across the three TfL endpoints:
+ *   - /Line/{ids}/Arrivals/{stopPointId}
+ *   - /StopPoint/{id}/Arrivals
+ *   - /Mode/{mode}/Arrivals
+ */
+export type ArrivalPrediction = {
+  stationName?: string;
+  lineName?: string;
+  platformName?: string;
+  destinationName?: string;
+  timeToStation?: number;
+  expectedArrival?: string;
+};
+
+/**
+ * Formats a single arrival prediction as a human-readable line.
+ *
+ * The line prefix (lineName) and station prefix (stationName) are included
+ * only when present — each endpoint populates a different subset of fields.
+ */
+export const formatArrival = (a: ArrivalPrediction): string => {
+  const mins = a.timeToStation != null ? Math.round(a.timeToStation / 60) : null;
+  const time = mins != null ? `${mins} min` : (a.expectedArrival ?? "?");
+  const prefix = [a.stationName, a.lineName].filter(Boolean).join(" — ");
+  return `  ${prefix ? `${prefix} → ` : "→ "}${a.destinationName ?? "?"}${a.platformName ? ` via ${a.platformName}` : ""} — ${time}`;
+};

--- a/src/mcp/tools/line.ts
+++ b/src/mcp/tools/line.ts
@@ -3,6 +3,7 @@ import { Effect, type ManagedRuntime } from "effect";
 import { z } from "zod";
 import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
+import { type ArrivalPrediction, formatArrival } from "../arrivals.ts";
 import { formatError, formatSuccess } from "../utils.ts";
 
 type LineStatus = { statusSeverityDescription?: string; reason?: string };
@@ -16,12 +17,6 @@ type Disruption = {
   category?: string;
   type?: string;
   description?: string;
-};
-type ArrivalPrediction = {
-  destinationName?: string;
-  platformName?: string;
-  timeToStation?: number;
-  expectedArrival?: string;
 };
 
 const formatLine = (line: Line): string => {
@@ -38,11 +33,6 @@ const formatDisruption = (d: Disruption): string =>
     `Type: ${d.type ?? "Unknown"}`,
     `Description: ${d.description ?? "None"}`,
   ].join("\n");
-
-const formatArrival = (a: ArrivalPrediction): string => {
-  const mins = a.timeToStation != null ? Math.round(a.timeToStation / 60) : null;
-  return `  → ${a.destinationName ?? "?"} via ${a.platformName ?? "?"} — ${mins != null ? `${mins} min` : (a.expectedArrival ?? "?")}`;
-};
 
 export const registerLineTools = (
   server: McpServer,

--- a/src/mcp/tools/mode.ts
+++ b/src/mcp/tools/mode.ts
@@ -3,15 +3,8 @@ import { Effect, type ManagedRuntime } from "effect";
 import { z } from "zod";
 import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
+import { type ArrivalPrediction, formatArrival } from "../arrivals.ts";
 import { formatError, formatSuccess } from "../utils.ts";
-
-type ArrivalPrediction = {
-  stationName?: string;
-  lineName?: string;
-  destinationName?: string;
-  timeToStation?: number;
-  expectedArrival?: string;
-};
 
 export const registerModeTools = (
   server: McpServer,
@@ -79,13 +72,7 @@ export const registerModeTools = (
           );
           if (!data.length) return `No arrivals found for mode: ${mode}`;
           const sorted = [...data].sort((a, b) => (a.timeToStation ?? 0) - (b.timeToStation ?? 0));
-          const formatted = sorted.slice(0, 50).map((a) => {
-            const mins =
-              a.timeToStation != null
-                ? `${Math.round(a.timeToStation / 60)} min`
-                : (a.expectedArrival ?? "?");
-            return `${a.stationName ?? "?"} — ${a.lineName ?? "?"} to ${a.destinationName ?? "?"} (${mins})`;
-          });
+          const formatted = sorted.slice(0, 50).map(formatArrival);
           return `Next arrivals for ${mode} (showing up to 50):\n\n${formatted.join("\n")}`;
         }),
       );

--- a/src/mcp/tools/stop-point.ts
+++ b/src/mcp/tools/stop-point.ts
@@ -3,6 +3,7 @@ import { Effect, type ManagedRuntime } from "effect";
 import { z } from "zod";
 import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
+import { type ArrivalPrediction, formatArrival } from "../arrivals.ts";
 import { formatError, formatSuccess } from "../utils.ts";
 
 type StopPoint = {
@@ -17,26 +18,12 @@ type StopPoint = {
   lines?: Array<{ id?: string; name?: string }>;
 };
 
-type ArrivalPrediction = {
-  stationName?: string;
-  lineName?: string;
-  platformName?: string;
-  destinationName?: string;
-  timeToStation?: number;
-  expectedArrival?: string;
-};
-
 const stopId = (s: StopPoint): string => s.icsCode ?? s.naptanId ?? s.id ?? "?";
 
 const formatStop = (s: StopPoint): string => {
   const modes = s.modes?.join(", ") ?? "?";
   const lines = s.lines?.map((l) => l.name ?? l.id).join(", ") ?? "";
   return `${s.commonName ?? "??"} — ID: ${stopId(s)} — ${s.stopType ?? "?"} — modes: ${modes}${lines ? ` — lines: ${lines}` : ""}`;
-};
-
-const formatArrival = (a: ArrivalPrediction): string => {
-  const mins = a.timeToStation != null ? Math.round(a.timeToStation / 60) : null;
-  return `  ${a.lineName ?? "?"} → ${a.destinationName ?? "?"} via ${a.platformName ?? "?"} — ${mins != null ? `${mins} min` : (a.expectedArrival ?? "?")}`;
 };
 
 export const registerStopPointTools = (


### PR DESCRIPTION
## Summary

- Introduces `src/mcp/arrivals.ts` with a single shared `ArrivalPrediction` type (superset of all fields across the three endpoints) and a unified `formatArrival` helper
- Removes the three independent, diverged local type definitions and formatter implementations from `line.ts`, `stop-point.ts`, and `mode.ts`
- All three tool files now import `ArrivalPrediction` and `formatArrival` from the shared module

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 19/19 pass
- [x] `bun run build` — 393 modules bundled

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)