### PR TITLE
refactor: add typed responses and formatting to raw JSON tools

### DIFF
--- a/src/mcp/tools/accident.ts
+++ b/src/mcp/tools/accident.ts
@@ -5,6 +5,35 @@ import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
 import { formatError, formatSuccess } from "../utils.ts";
 
+type AccidentCasualty = {
+  age?: number;
+  class?: string;
+  severity?: string;
+  mode?: string;
+  ageBand?: string;
+};
+
+type AccidentDetail = {
+  id?: number;
+  lat?: number;
+  lon?: number;
+  location?: string;
+  date?: string;
+  severity?: string;
+  borough?: string;
+  casualties?: AccidentCasualty[];
+  vehicles?: Array<{ type?: string }>;
+};
+
+const formatAccident = (a: AccidentDetail): string => {
+  const location = a.location ?? (a.lat != null ? `${a.lat}, ${a.lon}` : "unknown location");
+  const date = a.date ? a.date.slice(0, 10) : "?";
+  const casualties = a.casualties?.length ?? 0;
+  const severity = a.severity ?? "?";
+  const borough = a.borough ? ` (${a.borough})` : "";
+  return `${date} — ${severity} — ${location}${borough} — ${casualties} casualty(ies)`;
+};
+
 export const registerAccidentTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
@@ -31,9 +60,18 @@ export const registerAccidentTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown[]>(`/AccidentStats/${year}`);
-          const count = Array.isArray(data) ? data.length : "unknown";
-          return `Accident statistics for ${year} (${count} incidents):\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<AccidentDetail[]>(`/AccidentStats/${year}`);
+          if (!data.length) return `No accident records found for ${year}.`;
+          const bySeverity = data.reduce<Record<string, number>>((acc, a) => {
+            const key = a.severity ?? "Unknown";
+            acc[key] = (acc[key] ?? 0) + 1;
+            return acc;
+          }, {});
+          const summary = Object.entries(bySeverity)
+            .map(([sev, count]) => `${sev}: ${count}`)
+            .join(", ");
+          const recent = data.slice(0, 10).map(formatAccident).join("\n");
+          return `Accident statistics for ${year} (${data.length} total — ${summary}):\n\nFirst 10 incidents:\n${recent}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/cabwise.ts
+++ b/src/mcp/tools/cabwise.ts
@@ -5,6 +5,34 @@ import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
 import { formatError, formatSuccess } from "../utils.ts";
 
+type CabwiseOperator = {
+  OperatorId?: number;
+  TradingName?: string;
+  OrganisationName?: string;
+  CentreId?: number;
+  BookingsPhoneNumber?: string;
+  BookingsEmail?: string;
+  PublicAccess?: string;
+  OperatorType?: string;
+  WheelchairAccessible?: string;
+};
+
+type CabwiseResponse = {
+  Operators?: {
+    OperatorList?: CabwiseOperator[];
+  };
+};
+
+const formatOperator = (op: CabwiseOperator): string => {
+  const name = op.TradingName ?? op.OrganisationName ?? "Unknown";
+  const type = op.OperatorType ?? "?";
+  const phone = op.BookingsPhoneNumber ? `Tel: ${op.BookingsPhoneNumber}` : null;
+  const email = op.BookingsEmail ? `Email: ${op.BookingsEmail}` : null;
+  const wheelchair = op.WheelchairAccessible === "Yes" ? " [wheelchair accessible]" : "";
+  const contact = [phone, email].filter(Boolean).join(", ") || "no contact details";
+  return `${name} (${type})${wheelchair} — ${contact}`;
+};
+
 export const registerCabwiseTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
@@ -52,7 +80,7 @@ export const registerCabwiseTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Cabwise/search", {
+          const data = yield* client.request<CabwiseResponse>("/Cabwise/search", {
             lat,
             lon,
             radius,
@@ -62,7 +90,11 @@ export const registerCabwiseTools = (
             twentyFourSevenOnly,
             wc,
           });
-          return `Taxi/minicab operators near (${lat}, ${lon}):\n\n${JSON.stringify(data, null, 2)}`;
+          const operators = data.Operators?.OperatorList ?? [];
+          if (!operators.length)
+            return `No licensed taxi/minicab operators found near (${lat}, ${lon}).`;
+          const lines = operators.map(formatOperator);
+          return `Taxi/minicab operators near (${lat}, ${lon}) (${operators.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/line.ts
+++ b/src/mcp/tools/line.ts
@@ -175,11 +175,17 @@ export const registerLineTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(`/Line/Search/${encodeURIComponent(query)}`, {
-            modes,
-            serviceTypes,
-          });
-          return `Line search results for "${query}":\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<{
+            input?: string;
+            searchMatches?: Array<{ lineId?: string; lineName?: string; modeName?: string }>;
+          }>(`/Line/Search/${encodeURIComponent(query)}`, { modes, serviceTypes });
+          const matches = data.searchMatches ?? [];
+          if (!matches.length) return `No lines found matching "${query}".`;
+          const lines = matches.map(
+            (m) =>
+              `${m.lineName ?? m.lineId ?? "?"} (${m.modeName ?? "?"}) — ID: ${m.lineId ?? "?"}`,
+          );
+          return `Line search results for "${query}" (${matches.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -454,10 +460,30 @@ export const registerLineTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(`/Line/${encodeURIComponent(ids)}/Route`, {
-            serviceTypes,
-          });
-          return `Routes for ${ids}:\n\n${JSON.stringify(data, null, 2)}`;
+          type RouteSection = {
+            name?: string;
+            direction?: string;
+            originator?: string;
+            originationName?: string;
+            destination?: string;
+            destinationName?: string;
+            serviceType?: string;
+          };
+          type LineWithRoutes = Line & { routeSections?: RouteSection[] };
+          const data = yield* client.request<LineWithRoutes[]>(
+            `/Line/${encodeURIComponent(ids)}/Route`,
+            { serviceTypes },
+          );
+          if (!data.length) return `No routes found for lines: ${ids}`;
+          const sections = data.flatMap((line) =>
+            (line.routeSections ?? []).map(
+              (r) =>
+                `${line.name ?? line.id ?? "?"} (${r.serviceType ?? "Regular"}) ${r.direction ?? "?"}: ${r.originationName ?? r.originator ?? "?"} → ${r.destinationName ?? r.destination ?? "?"}`,
+            ),
+          );
+          return sections.length
+            ? `Routes for ${ids} (${sections.length} sections):\n\n${sections.join("\n")}`
+            : `Lines found but no route sections for: ${ids}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -488,11 +514,30 @@ export const registerLineTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/Line/${encodeURIComponent(id)}/Route/Sequence/${direction}`,
-            { serviceTypes, excludeCrowding },
-          );
-          return `Stop sequence for ${id} (${direction}):\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<{
+            lineId?: string;
+            lineName?: string;
+            direction?: string;
+            stopPointSequences?: Array<{
+              direction?: string;
+              branchId?: number;
+              nextBranchIds?: number[];
+              prevBranchIds?: number[];
+              stopPoint?: Array<{ id?: string; name?: string; stopLetter?: string }>;
+            }>;
+            orderedLineRoutes?: Array<{ name?: string; naptanIds?: string[] }>;
+          }>(`/Line/${encodeURIComponent(id)}/Route/Sequence/${direction}`, {
+            serviceTypes,
+            excludeCrowding,
+          });
+          const sequences = data.stopPointSequences ?? [];
+          if (!sequences.length)
+            return `No stop sequence found for ${data.lineName ?? id} (${direction}).`;
+          const sections = sequences.map((seq, i) => {
+            const stops = (seq.stopPoint ?? []).map((s) => s.name ?? s.id ?? "?").join(" → ");
+            return `Branch ${seq.branchId ?? i + 1} (${seq.direction ?? direction}): ${stops}`;
+          });
+          return `Stop sequence for ${data.lineName ?? id} (${direction}):\n\n${sections.join("\n\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -522,7 +567,11 @@ export const registerLineTools = (
             `/Line/Mode/${encodeURIComponent(modes)}/Route`,
             { serviceTypes },
           );
-          return `Routes for mode(s) "${modes}" (${data.length} lines):\n\n${JSON.stringify(data, null, 2)}`;
+          if (!data.length) return `No routes found for mode(s): ${modes}`;
+          const lines = data.map(
+            (l) => `${l.name ?? l.id ?? "?"} (${l.modeName ?? "?"}) — ID: ${l.id ?? "?"}`,
+          );
+          return `Routes for mode(s) "${modes}" (${data.length} lines):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -5,6 +5,30 @@ import type { TflDisambiguationError, TflError } from "../../domain/errors.ts";
 import { TflClient } from "../../domain/TflClient.ts";
 import { formatError, formatSuccess } from "../utils.ts";
 
+type SearchMatch = {
+  id?: string;
+  url?: string;
+  name?: string;
+  lat?: number;
+  lon?: number;
+  zone?: string;
+  modes?: string[];
+};
+
+type SearchResponse = {
+  query?: string;
+  total?: number;
+  matches?: SearchMatch[];
+};
+
+const formatMatch = (m: SearchMatch): string => {
+  const parts = [m.name ?? m.id ?? "?"];
+  if (m.modes?.length) parts.push(`modes: ${m.modes.join(", ")}`);
+  if (m.zone) parts.push(`zone: ${m.zone}`);
+  if (m.url) parts.push(m.url);
+  return parts.join(" — ");
+};
+
 export const registerSearchTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
@@ -29,8 +53,11 @@ export const registerSearchTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Search", { query });
-          return `Search results for "${query}":\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<SearchResponse>("/Search", { query });
+          const matches = data.matches ?? [];
+          if (!matches.length) return `No results found for "${query}".`;
+          const header = `Search results for "${query}" (${matches.length} of ${data.total ?? "?"}):`;
+          return `${header}\n\n${matches.map(formatMatch).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -55,10 +82,11 @@ export const registerSearchTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Search/BusSchedules", {
-            query,
-          });
-          return `Bus schedule search results for "${query}":\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<SearchResponse>("/Search/BusSchedules", { query });
+          const matches = data.matches ?? [];
+          if (!matches.length) return `No bus schedule documents found for "${query}".`;
+          const header = `Bus schedule results for "${query}" (${matches.length} of ${data.total ?? "?"}):`;
+          return `${header}\n\n${matches.map(formatMatch).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -81,8 +109,8 @@ export const registerSearchTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Search/Meta/Categories");
-          return `Search categories:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<string[]>("/Search/Meta/Categories");
+          return `Search categories (${data.length}):\n\n${data.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -105,8 +133,8 @@ export const registerSearchTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Search/Meta/SearchProviders");
-          return `Search providers:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<string[]>("/Search/Meta/SearchProviders");
+          return `Search providers (${data.length}):\n\n${data.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -129,8 +157,8 @@ export const registerSearchTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/Search/Meta/Sorts");
-          return `Search sort options:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<string[]>("/Search/Meta/Sorts");
+          return `Search sort options (${data.length}):\n\n${data.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/stop-point.ts
+++ b/src/mcp/tools/stop-point.ts
@@ -98,8 +98,14 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/StopPoint/Meta/Categories");
-          return `StopPoint categories:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<
+            Array<{ category?: string; availableKeys?: string[] }>
+          >("/StopPoint/Meta/Categories");
+          const lines = data.map((c) => {
+            const keys = c.availableKeys?.join(", ") ?? "none";
+            return `${c.category ?? "?"}: ${keys}`;
+          });
+          return `StopPoint categories (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -395,12 +401,14 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>("/StopPoint/ServiceTypes", {
-            id,
-            lineIds,
-            modes,
-          });
-          return `Service types at stop ${id}:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<
+            Array<{ lineName?: string; lineId?: string; serviceType?: { name?: string } }>
+          >("/StopPoint/ServiceTypes", { id, lineIds, modes });
+          if (!data.length) return `No service types found for stop ${id}.`;
+          const lines = data.map(
+            (s) => `${s.lineName ?? s.lineId ?? "?"} — ${s.serviceType?.name ?? "?"}`,
+          );
+          return `Service types at stop ${id}:\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -464,12 +472,27 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown[]>(
-            `/StopPoint/${encodeURIComponent(id)}/ArrivalDepartures`,
-            { lineIds },
-          );
+          const data = yield* client.request<
+            Array<{
+              stationName?: string;
+              lineName?: string;
+              platformName?: string;
+              destinationName?: string;
+              scheduledTimeOfArrival?: string;
+              scheduledTimeOfDeparture?: string;
+              estimatedTimeOfArrival?: string;
+              estimatedTimeOfDeparture?: string;
+            }>
+          >(`/StopPoint/${encodeURIComponent(id)}/ArrivalDepartures`, { lineIds });
           if (!data.length) return `No arrivals/departures at stop ${id}.`;
-          return `Arrival/Departures at ${id}:\n\n${JSON.stringify(data, null, 2)}`;
+          const lines = data.map((d) => {
+            const dest = d.destinationName ?? "?";
+            const platform = d.platformName ? ` (${d.platformName})` : "";
+            const arr = d.estimatedTimeOfArrival ?? d.scheduledTimeOfArrival ?? "?";
+            const dep = d.estimatedTimeOfDeparture ?? d.scheduledTimeOfDeparture ?? "?";
+            return `  ${d.lineName ?? "?"} → ${dest}${platform} — arr: ${arr} dep: ${dep}`;
+          });
+          return `Arrival/Departures at ${data[0]?.stationName ?? id}:\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -504,15 +527,37 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(ids)}/Disruption`,
-            {
-              getFamily,
-              includeRouteBlockedStops,
-              flattenResponse,
-            },
-          );
-          return `Disruptions at ${ids}:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<
+            Array<{
+              category?: string;
+              type?: string;
+              categoryDescription?: string;
+              description?: string;
+              summary?: string;
+              additionalInfo?: string;
+              affectedRoutes?: Array<{ name?: string }>;
+              affectedStops?: Array<{ commonName?: string }>;
+            }>
+          >(`/StopPoint/${encodeURIComponent(ids)}/Disruption`, {
+            getFamily,
+            includeRouteBlockedStops,
+            flattenResponse,
+          });
+          if (!data.length) return `No disruptions at stop(s) ${ids}.`;
+          const lines = data.map((d) => {
+            const parts = [
+              `Category: ${d.categoryDescription ?? d.category ?? "?"}`,
+              `Type: ${d.type ?? "?"}`,
+            ];
+            if (d.description) parts.push(`Info: ${d.description}`);
+            else if (d.summary) parts.push(`Info: ${d.summary}`);
+            if (d.affectedStops?.length)
+              parts.push(
+                `Affected stops: ${d.affectedStops.map((s) => s.commonName ?? "?").join(", ")}`,
+              );
+            return parts.join("\n");
+          });
+          return `Disruptions at ${ids} (${data.length}):\n\n${lines.join("\n---\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -646,11 +691,22 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(id)}/Route`,
-            { serviceTypes },
+          const data = yield* client.request<
+            Array<{
+              lineId?: string;
+              lineName?: string;
+              direction?: string;
+              originationName?: string;
+              destinationName?: string;
+              serviceType?: string;
+            }>
+          >(`/StopPoint/${encodeURIComponent(id)}/Route`, { serviceTypes });
+          if (!data.length) return `No route sections found for stop ${id}.`;
+          const lines = data.map(
+            (r) =>
+              `${r.lineName ?? r.lineId ?? "?"} (${r.serviceType ?? "Regular"}) ${r.direction ?? "?"}: ${r.originationName ?? "?"} → ${r.destinationName ?? "?"}`,
           );
-          return `Routes serving stop ${id}:\n\n${JSON.stringify(data, null, 2)}`;
+          return `Routes serving stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -678,11 +734,26 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(id)}/Crowding/${encodeURIComponent(line)}`,
-            { direction },
-          );
-          return `Crowding data for ${id} on ${line} (${direction}):\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<
+            Array<{
+              naptanId?: string;
+              commonName?: string;
+              passengerFlows?: Array<{ timeSlice?: string; value?: number }>;
+              workerFlows?: Array<{ timeSlice?: string; value?: number }>;
+            }>
+          >(`/StopPoint/${encodeURIComponent(id)}/Crowding/${encodeURIComponent(line)}`, {
+            direction,
+          });
+          if (!data.length) return `No crowding data available for stop ${id} on ${line}.`;
+          const sections = data.map((stop) => {
+            const name = stop.commonName ?? stop.naptanId ?? "?";
+            if (!stop.passengerFlows?.length) return `${name}: no flow data`;
+            const peak = [...(stop.passengerFlows ?? [])].sort(
+              (a, b) => (b.value ?? 0) - (a.value ?? 0),
+            )[0];
+            return `${name}: peak at ${peak?.timeSlice ?? "?"} (${peak?.value ?? "?"} passengers)`;
+          });
+          return `Crowding data for ${id} on ${line} (${direction}):\n\n${sections.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -708,10 +779,25 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(stopPointId)}/CarParks`,
-          );
-          return `Car parks near stop ${stopPointId}:\n\n${JSON.stringify(data, null, 2)}`;
+          const data = yield* client.request<
+            Array<{
+              id?: string;
+              name?: string;
+              carParkId?: string;
+              accessPoints?: Array<{ name?: string }>;
+              facilities?: Array<{ name?: string; description?: string; paymentMethods?: string }>;
+            }>
+          >(`/StopPoint/${encodeURIComponent(stopPointId)}/CarParks`);
+          if (!data.length) return `No car parks found near stop ${stopPointId}.`;
+          const lines = data.map((cp) => {
+            const id = cp.carParkId ?? cp.id ?? "?";
+            const name = cp.name ?? id;
+            const spaces =
+              cp.facilities?.map((f) => `${f.name ?? "?"}: ${f.description ?? "?"}`).join(", ") ??
+              "details unavailable";
+            return `${name} (${id}) — ${spaces}`;
+          });
+          return `Car parks near stop ${stopPointId} (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -736,10 +822,21 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(stopPointId)}/TaxiRanks`,
+          const data = yield* client.request<
+            Array<{
+              id?: string;
+              commonName?: string;
+              placeType?: string;
+              lat?: number;
+              lon?: number;
+            }>
+          >(`/StopPoint/${encodeURIComponent(stopPointId)}/TaxiRanks`);
+          if (!data.length) return `No taxi ranks found near stop ${stopPointId}.`;
+          const lines = data.map(
+            (t) =>
+              `${t.commonName ?? t.id ?? "?"} (${t.placeType ?? "TaxiRank"}) — ${t.lat != null ? `${t.lat}, ${t.lon}` : "no coords"}`,
           );
-          return `Taxi ranks near stop ${stopPointId}:\n\n${JSON.stringify(data, null, 2)}`;
+          return `Taxi ranks near stop ${stopPointId} (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -767,11 +864,21 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<unknown>(
-            `/StopPoint/${encodeURIComponent(id)}/placeTypes`,
-            { placeTypes },
+          const data = yield* client.request<
+            Array<{
+              id?: string;
+              commonName?: string;
+              placeType?: string;
+              lat?: number;
+              lon?: number;
+            }>
+          >(`/StopPoint/${encodeURIComponent(id)}/placeTypes`, { placeTypes });
+          if (!data.length) return `No places of type "${placeTypes}" found at stop ${id}.`;
+          const lines = data.map(
+            (p) =>
+              `${p.commonName ?? p.id ?? "?"} (${p.placeType ?? "?"}) — ${p.lat != null ? `${p.lat}, ${p.lon}` : "no coords"}`,
           );
-          return `Places of type "${placeTypes}" at stop ${id}:\n\n${JSON.stringify(data, null, 2)}`;
+          return `Places of type "${placeTypes}" at stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);


### PR DESCRIPTION
## Summary

- Replaced `client.request<unknown>` + `JSON.stringify` with typed interfaces and human-readable formatters across all affected tools
- **stop-point.ts**: typed and formatted `stoppoint_meta_categories`, `stoppoint_service_types`, `stoppoint_arrival_departures`, `stoppoint_disruptions`, `stoppoint_route`, `stoppoint_crowding`, `stoppoint_car_parks`, `stoppoint_taxi_ranks`, `stoppoint_place_types`
- **line.ts**: typed and formatted `line_search`, `line_routes`, `line_route_sequence`, `line_routes_by_mode`
- **search.ts**: typed and formatted all 4 tools (`search`, `search_bus_schedules`, `search_meta_categories`, `search_meta_providers`, `search_meta_sorts`)
- **accident.ts**: typed `AccidentDetail` with severity breakdown summary and first-10 incidents list
- **cabwise.ts**: typed `CabwiseResponse`/`CabwiseOperator` with name, type, contact, and wheelchair flag

## Test plan

- [x] `bun run typecheck` — no type errors
- [x] `bun run lint` — no lint/format errors
- [x] `bun run build` — bundles cleanly
- [x] `bun test` — 19 tests pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)