### PR TITLE
refactor(main): remove unnecessary Layer.mergeAll wrapper in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env bun
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { Layer, ManagedRuntime } from "effect";
+import { ManagedRuntime } from "effect";
 import { TflClientLive } from "./infra/TflClientLive.ts";
 import { createMcpServer } from "./mcp/server.ts";
 
-const layer = Layer.mergeAll(TflClientLive);
-
-const runtime = ManagedRuntime.make(layer);
+const runtime = ManagedRuntime.make(TflClientLive);
 
 const server = createMcpServer(runtime);
 


### PR DESCRIPTION
## What

Removes the intermediate `Layer.mergeAll(TflClientLive)` call and passes `TflClientLive` directly to `ManagedRuntime.make`. Also removes the now-unused `Layer` import.

## Why

`Layer.mergeAll` with a single argument is a no-op. The canonical form from the MCP blueprint passes the layer directly.

## Test plan

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes

Closes #16