### PR TITLE
feat(domain): add models.ts with Schema.Class definitions for domain types

### DIFF
--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -1,4 +1,5 @@
 import { Data } from "effect";
+import type { DisambiguationResult } from "./models.ts";
 
 export class TflError extends Data.TaggedError("TflError")<{
   readonly message: string;
@@ -8,27 +9,3 @@ export class TflError extends Data.TaggedError("TflError")<{
 export class TflDisambiguationError extends Data.TaggedError("TflDisambiguationError")<{
   readonly result: DisambiguationResult;
 }> {}
-
-export type DisambiguationOption = {
-  readonly parameterValue: string;
-  readonly place: {
-    readonly commonName?: string;
-    readonly placeType?: string;
-    readonly lat?: number;
-    readonly lon?: number;
-    readonly naptanId?: string;
-    readonly icsCode?: string;
-  };
-  readonly matchQuality: number;
-};
-
-export type DisambiguationResult = {
-  readonly fromLocationDisambiguation?: {
-    readonly matchStatus: string;
-    readonly disambiguationOptions?: DisambiguationOption[];
-  };
-  readonly toLocationDisambiguation?: {
-    readonly matchStatus: string;
-    readonly disambiguationOptions?: DisambiguationOption[];
-  };
-};

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1,0 +1,30 @@
+import { Schema } from "effect";
+
+const DisambiguationPlaceSchema = Schema.Struct({
+  commonName: Schema.optional(Schema.String),
+  placeType: Schema.optional(Schema.String),
+  lat: Schema.optional(Schema.Number),
+  lon: Schema.optional(Schema.Number),
+  naptanId: Schema.optional(Schema.String),
+  icsCode: Schema.optional(Schema.String),
+});
+
+export class DisambiguationOption extends Schema.Class<DisambiguationOption>(
+  "DisambiguationOption",
+)({
+  parameterValue: Schema.String,
+  place: DisambiguationPlaceSchema,
+  matchQuality: Schema.Number,
+}) {}
+
+const DisambiguationSideSchema = Schema.Struct({
+  matchStatus: Schema.String,
+  disambiguationOptions: Schema.optional(Schema.Array(DisambiguationOption)),
+});
+
+export class DisambiguationResult extends Schema.Class<DisambiguationResult>(
+  "DisambiguationResult",
+)({
+  fromLocationDisambiguation: Schema.optional(DisambiguationSideSchema),
+  toLocationDisambiguation: Schema.optional(DisambiguationSideSchema),
+}) {}

--- a/src/infra/TflClientLive.ts
+++ b/src/infra/TflClientLive.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Option } from "effect";
 import { TflApiKeyConfig } from "../config.ts";
-import { type DisambiguationResult, TflDisambiguationError, TflError } from "../domain/errors.ts";
+import { TflDisambiguationError, TflError } from "../domain/errors.ts";
+import type { DisambiguationResult } from "../domain/models.ts";
 import { TflClient } from "../domain/TflClient.ts";
 
 const TFL_API_BASE = "https://api.tfl.gov.uk";

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,6 +1,6 @@
 import type { Cause } from "effect";
 import { Cause as CauseModule } from "effect";
-import type { DisambiguationResult } from "../domain/errors.ts";
+import type { DisambiguationResult } from "../domain/models.ts";
 
 export const formatSuccess = (data: unknown) => ({
   content: [


### PR DESCRIPTION
## What

Creates `src/domain/models.ts` with `Schema.Class` definitions for `DisambiguationOption` and `DisambiguationResult`. Removes the plain TypeScript type aliases from `errors.ts` and updates all import sites (`TflClientLive.ts`, `mcp/utils.ts`) to use the new canonical location.

## Why

The MCP blueprint requires domain models to live in `src/domain/models.ts` as `Schema.Class` definitions. The existing plain `type` definitions in `errors.ts` were misplaced.

## Test plan

- [x] `bun test` passes (19 tests)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes

Closes #17