### PR TITLE
fix(tools): use z.coerce.number() for numeric MCP parameters

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "files": {
-    "includes": ["**", "!dist", "!node_modules"]
+    "includes": ["**", "!dist", "!node_modules", "!.claude"]
   },
   "formatter": {
     "enabled": true,

--- a/src/mcp/tools/accident.ts
+++ b/src/mcp/tools/accident.ts
@@ -42,7 +42,7 @@ export const registerAccidentTools = (
     "accident_stats",
     "Gets all accident details for accidents occurring in the specified year in London.",
     {
-      year: z
+      year: z.coerce
         .number()
         .int()
         .min(2005)

--- a/src/mcp/tools/line.ts
+++ b/src/mcp/tools/line.ts
@@ -319,7 +319,7 @@ export const registerLineTools = (
     "line_status_by_severity",
     "Gets all lines currently at a given severity level. Use line_meta_severity to get severity codes.",
     {
-      severity: z
+      severity: z.coerce
         .number()
         .int()
         .describe(

--- a/src/mcp/tools/mode.ts
+++ b/src/mcp/tools/mode.ts
@@ -46,7 +46,7 @@ export const registerModeTools = (
         .describe(
           "Transport mode (e.g. 'tube', 'bus', 'dlr', 'overground', 'elizabeth-line', 'tram')",
         ),
-      count: z
+      count: z.coerce
         .number()
         .int()
         .positive()


### PR DESCRIPTION
## Summary

- `mode_arrivals` `count`, `accident_stats` `year`, and `line_status_by_severity` `severity` all declared `z.number()` but the MCP framework serialises every tool argument as a string, causing `Expected number, received string` at runtime
- Switched all three to `z.coerce.number()` so string inputs are coerced to numbers before Zod validates them
- Also excludes `.claude/` from biome so local settings files don't fail the pre-commit lint hook

## Test plan

- [ ] Call `mode_arrivals` with `count: 5` — previously crashed, now returns arrivals
- [ ] Call `accident_stats` with `year: 2023` — previously crashed, now returns stats
- [ ] Call `line_status_by_severity` with `severity: 10` — previously crashed, now returns lines
- [ ] `bun run lint && bun run typecheck && bun test` all pass

Closes #22