### PR TITLE
fix(stop-point): normalise single-object API response to array

### DIFF
--- a/src/mcp/tools/stop-point.ts
+++ b/src/mcp/tools/stop-point.ts
@@ -201,9 +201,11 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<StopPoint[]>(`/StopPoint/${encodeURIComponent(ids)}`, {
-            includeCrowdingData,
-          });
+          const raw = yield* client.request<StopPoint | StopPoint[]>(
+            `/StopPoint/${encodeURIComponent(ids)}`,
+            { includeCrowdingData },
+          );
+          const data = Array.isArray(raw) ? raw : [raw];
           return `Stop point details:\n\n${data.map(formatStop).join("\n")}`;
         }),
       );
@@ -336,10 +338,11 @@ export const registerStopPointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<StopPoint[]>(
+          const raw = yield* client.request<StopPoint | StopPoint[]>(
             `/StopPoint/Mode/${encodeURIComponent(modes)}`,
             { page },
           );
+          const data = Array.isArray(raw) ? raw : [raw];
           return `Stop points for mode(s) "${modes}" (page ${page ?? 1}, ${data.length} results):\n\n${data.map(formatStop).join("\n")}`;
         }),
       );


### PR DESCRIPTION
## Summary

- TfL returns a plain object (not an array) when exactly one stop point matches a lookup by ID or mode
- `stoppoint_by_ids` and `stoppoint_by_mode` both called `.map()` directly on the raw response, crashing with `data.map is not a function`
- Fixed by normalising the response with `Array.isArray(raw) ? raw : [raw]` before mapping

## Test plan

- [ ] Call `stoppoint_by_ids` with a single Naptan ID (e.g. `940GZZLUVIC`) — previously crashed, now returns stop details
- [ ] Call `stoppoint_by_mode` for a mode with one result — previously crashed, now returns stop list
- [ ] Multiple IDs still work correctly (array path)
- [ ] `bun test` passes

Closes #23