### PR TITLE
fix(formatters): correct field names and add road meta tools

### DIFF
--- a/src/mcp/tools/journey.ts
+++ b/src/mcp/tools/journey.ts
@@ -195,10 +195,10 @@ export const registerJourneyTools = (
         Effect.gen(function* () {
           const client = yield* TflClient;
           const data =
-            yield* client.request<Array<{ mode?: string; isTflService?: boolean }>>(
+            yield* client.request<Array<{ modeName?: string; isTflService?: boolean }>>(
               "/Journey/Meta/Modes",
             );
-          const modes = data.map((m) => `${m.mode ?? "??"} (TfL: ${m.isTflService ?? false})`);
+          const modes = data.map((m) => `${m.modeName ?? "??"} (TfL: ${m.isTflService ?? false})`);
           return `Available journey modes:\n\n${modes.join("\n")}`;
         }),
       );

--- a/src/mcp/tools/place.ts
+++ b/src/mcp/tools/place.ts
@@ -146,8 +146,9 @@ export const registerPlaceTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<Array<{ type?: string }>>("/Place/Meta/PlaceTypes");
-          return `Place types:\n\n${data.map((t) => t.type ?? "?").join("\n")}`;
+          const data =
+            yield* client.request<Array<{ placeName?: string }>>("/Place/Meta/PlaceTypes");
+          return `Place types:\n\n${data.map((t) => t.placeName ?? "?").join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/road.ts
+++ b/src/mcp/tools/road.ts
@@ -53,6 +53,62 @@ export const registerRoadTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
+  // --- Meta ---
+  server.tool(
+    "road_meta_categories",
+    "Gets the list of valid road disruption category names.",
+    {},
+    {
+      title: "Road Disruption Categories",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async () => {
+      const result = await runtime.runPromiseExit(
+        Effect.gen(function* () {
+          const client = yield* TflClient;
+          const data = yield* client.request<string[]>("/Road/Meta/Categories");
+          return `Road disruption categories:\n\n${data.join("\n")}`;
+        }),
+      );
+      if (result._tag === "Failure") return formatError(result.cause);
+      return formatSuccess(result.value);
+    },
+  );
+
+  server.tool(
+    "road_meta_severities",
+    "Gets the list of valid road disruption severity levels.",
+    {},
+    {
+      title: "Road Disruption Severities",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async () => {
+      const result = await runtime.runPromiseExit(
+        Effect.gen(function* () {
+          const client = yield* TflClient;
+          const data =
+            yield* client.request<
+              Array<{ description?: string; levelOfInterest?: string; ordinal?: number }>
+            >("/Road/Meta/Severities");
+          const rows = data.map(
+            (s) =>
+              `${s.description ?? "?"} (level: ${s.levelOfInterest ?? "?"}, ordinal: ${s.ordinal ?? "?"})`,
+          );
+          return `Road disruption severities:\n\n${rows.join("\n")}`;
+        }),
+      );
+      if (result._tag === "Failure") return formatError(result.cause);
+      return formatSuccess(result.value);
+    },
+  );
+
   server.tool(
     "road_all",
     "Gets status for all roads on the TfL Road Network (TLRN).",

--- a/src/mcp/tools/stop-point.ts
+++ b/src/mcp/tools/stop-point.ts
@@ -11,6 +11,7 @@ type StopPoint = {
   naptanId?: string;
   icsCode?: string;
   commonName?: string;
+  name?: string;
   stopType?: string;
   lat?: number;
   lon?: number;
@@ -23,7 +24,7 @@ const stopId = (s: StopPoint): string => s.icsCode ?? s.naptanId ?? s.id ?? "?";
 const formatStop = (s: StopPoint): string => {
   const modes = s.modes?.join(", ") ?? "?";
   const lines = s.lines?.map((l) => l.name ?? l.id).join(", ") ?? "";
-  return `${s.commonName ?? "??"} — ID: ${stopId(s)} — ${s.stopType ?? "?"} — modes: ${modes}${lines ? ` — lines: ${lines}` : ""}`;
+  return `${s.commonName ?? s.name ?? "??"} — ID: ${stopId(s)} — ${s.stopType ?? "?"} — modes: ${modes}${lines ? ` — lines: ${lines}` : ""}`;
 };
 
 export const registerStopPointTools = (


### PR DESCRIPTION
## Summary

Four display formatter bugs fixed:

- **`journey_modes`**: TfL's `/Journey/Meta/Modes` returns `modeName` not `mode`; the formatter was reading the wrong key and falling through to `??`
- **`place_meta_types`**: TfL's `/Place/Meta/PlaceTypes` returns `placeName` not `type`; same issue
- **`stoppoint_search`**: `formatStop` only checked `commonName`; TfL search result objects use `name` instead — added `name` as a fallback in the type and the formatter
- **`road_meta_severities` / `road_meta_categories`**: Tools were missing entirely; added both with properly typed responses (`description`, `levelOfInterest`, `ordinal`) so the formatter extracts named fields rather than stringifying raw objects

## Test plan

- [ ] `journey_modes` — mode names now display instead of `??`
- [ ] `place_meta_types` — type names now display instead of `??`
- [ ] `stoppoint_search` — stop names now display correctly for search results
- [ ] `road_meta_severities` — returns severity descriptions instead of `[object Object]`
- [ ] `road_meta_categories` — returns category strings
- [ ] `bun test` passes

Closes #24