### PR TITLE
fix(line): normalise YYYYMMDD dates to ISO format for date-range status

### DIFF
--- a/src/mcp/tools/line.ts
+++ b/src/mcp/tools/line.ts
@@ -367,11 +367,15 @@ export const registerLineTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          const toIso = (d: string): string =>
+            d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : d;
+          const start = toIso(startDate);
+          const end = toIso(endDate);
           const data = yield* client.request<Line[]>(
-            `/Line/${encodeURIComponent(ids)}/Status/${encodeURIComponent(startDate)}/to/${encodeURIComponent(endDate)}`,
+            `/Line/${encodeURIComponent(ids)}/Status/${encodeURIComponent(start)}/to/${encodeURIComponent(end)}`,
             { detail },
           );
-          return `Status for ${ids} between ${startDate} and ${endDate}:\n\n${data.map(formatLine).join("\n")}`;
+          return `Status for ${ids} between ${start} and ${end}:\n\n${data.map(formatLine).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);


### PR DESCRIPTION
## Summary

- `line_status_by_date_range` was passing dates straight through to the TfL API URL — but TfL requires `YYYY-MM-DD` format, not `YYYYMMDD`
- Added a `toIso()` helper inside the handler: if the input is exactly 8 characters (compact format), it inserts dashes at positions 4 and 7; otherwise it passes the string unchanged (so ISO dates with dashes already in them work too)

## Test plan

- [ ] `line_status_by_date_range` with `startDate: "20240301"` — previously returned a TfL 400/404, now passes `2024-03-01` to the API correctly
- [ ] `line_status_by_date_range` with `startDate: "2024-03-01"` — already-hyphenated date passes through unchanged
- [ ] `bun test` passes

Closes #25