### PR TITLE
fix(place): type place_meta_types response as string[] not object array

### DIFF
--- a/src/mcp/tools/place.ts
+++ b/src/mcp/tools/place.ts
@@ -146,9 +146,8 @@ export const registerPlaceTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data =
-            yield* client.request<Array<{ category?: string }>>("/Place/Meta/PlaceTypes");
-          return `Place types:\n\n${data.map((t) => t.category ?? "?").join("\n")}`;
+          const data = yield* client.request<string[]>("/Place/Meta/PlaceTypes");
+          return `Place types:\n\n${data.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);


### PR DESCRIPTION
## Summary

- Fixes `place_meta_types` rendering `?` for every entry
- TfL `/Place/Meta/PlaceTypes` returns a plain `string[]`, not `Array<{ category?: string }>`
- Removed the `.map((t) => t.category ?? "?")` accessor; join strings directly

Closes #30