### PR TITLE
feat(tools): consolidate 74 tools to 41 by merging siblings and removing meta tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daanrongen/tfl-mcp",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "MCP server for the Transport for London (TfL) Unified API — lines, journeys, stop points, arrivals, bike points, and more over stdio",
   "type": "module",
   "bin": {

--- a/src/mcp/tools/bike-point.ts
+++ b/src/mcp/tools/bike-point.ts
@@ -35,39 +35,14 @@ export const registerBikePointTools = (
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
   server.tool(
-    "bike_points_all",
-    "Gets all Santander Cycles (Boris Bikes) docking station locations in London with live availability (bikes, empty docks, total docks).",
-    {},
-    {
-      title: "All Bike Points",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<BikePoint[]>("/BikePoint");
-          if (!data.length) return "No bike points found.";
-          return `Found ${data.length} bike points:\n\n${data.map(formatBikePoint).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
     "bike_point_search",
-    "Search for Santander Cycles docking stations by name or nearby landmark. Returns matching stations.",
+    "Search for Santander Cycles docking stations by name or nearby landmark, or omit query to get all ~800 bike points.",
     {
       query: z
         .string()
-        .min(1)
+        .optional()
         .describe(
-          "Search term for bike station name or nearby landmark (e.g. 'Waterloo', 'Hyde Park')",
+          "Search term for bike station name or nearby landmark (e.g. 'Waterloo', 'Hyde Park'). Omit to get all bike points.",
         ),
     },
     {
@@ -81,11 +56,14 @@ export const registerBikePointTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<BikePoint[]>("/BikePoint/Search", {
-            query,
-          });
-          if (!data.length) return `No bike points found matching "${query}".`;
-          return `Found ${data.length} bike points matching "${query}":\n\n${data.map(formatBikePoint).join("\n")}`;
+          if (query) {
+            const data = yield* client.request<BikePoint[]>("/BikePoint/Search", { query });
+            if (!data.length) return `No bike points found matching "${query}".`;
+            return `Found ${data.length} bike points matching "${query}":\n\n${data.map(formatBikePoint).join("\n")}`;
+          }
+          const data = yield* client.request<BikePoint[]>("/BikePoint");
+          if (!data.length) return "No bike points found.";
+          return `Found ${data.length} bike points:\n\n${data.map(formatBikePoint).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/journey.ts
+++ b/src/mcp/tools/journey.ts
@@ -51,7 +51,7 @@ export const registerJourneyTools = (
 ) => {
   server.tool(
     "journey_plan",
-    "Plan a journey across London's transport network. Supports tube, bus, overground, Elizabeth line, DLR, cycling and walking. Returns journey options with duration, modes, and step-by-step legs.",
+    "Plan a journey across London's transport network. Valid modes: tube, bus, dlr, overground, elizabeth-line, national-rail, tflrail, tram, cable-car, walking, cycle. Returns journey options with duration, modes, and step-by-step legs.",
     {
       from: z
         .string()
@@ -173,34 +173,6 @@ export const registerJourneyTools = (
             Effect.succeed(formatDisambiguation(e.result)),
           ),
         ),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "journey_modes",
-    "Gets all available transport modes supported by the TfL journey planner (e.g. tube, bus, dlr, overground, elizabeth-line, cycling, walking).",
-    {},
-    {
-      title: "Journey Modes",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data =
-            yield* client.request<Array<{ modeName?: string; isTflService?: boolean }>>(
-              "/Journey/Meta/Modes",
-            );
-          const modes = data.map((m) => `${m.modeName ?? "??"} (TfL: ${m.isTflService ?? false})`);
-          return `Available journey modes:\n\n${modes.join("\n")}`;
-        }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
       return formatSuccess(result.value);

--- a/src/mcp/tools/line.ts
+++ b/src/mcp/tools/line.ts
@@ -38,114 +38,6 @@ export const registerLineTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
-  // --- Meta ---
-  server.tool(
-    "line_meta_modes",
-    "Gets all valid line modes (e.g. tube, bus, dlr, overground, elizabeth-line, tram, cable-car).",
-    {},
-    {
-      title: "Line Meta Modes",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Array<{ modeName?: string }>>("/Line/Meta/Modes");
-          return `Available line modes: ${data.map((m) => m.modeName ?? "??").join(", ")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_meta_severity",
-    "Gets all valid severity codes and their descriptions used in line status.",
-    {},
-    {
-      title: "Line Severity Codes",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data =
-            yield* client.request<
-              Array<{
-                modeName?: string;
-                severityLevel?: number;
-                description?: string;
-              }>
-            >("/Line/Meta/Severity");
-          const rows = data.map(
-            (s) =>
-              `Level ${s.severityLevel ?? "?"} (${s.modeName ?? "?"}): ${s.description ?? "?"}`,
-          );
-          return `Severity codes:\n\n${rows.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_meta_disruption_categories",
-    "Gets all valid disruption category names used by TfL lines.",
-    {},
-    {
-      title: "Disruption Categories",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Line/Meta/DisruptionCategories");
-          return `Disruption categories:\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_meta_service_types",
-    "Gets all valid service types for TfL lines (e.g. Regular, Night).",
-    {},
-    {
-      title: "Line Service Types",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Line/Meta/ServiceTypes");
-          return `Service types: ${data.join(", ")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
   // --- Line lookup ---
   server.tool(
     "line_search",
@@ -194,56 +86,37 @@ export const registerLineTools = (
   );
 
   server.tool(
-    "line_by_ids",
-    "Gets details for one or more specific TfL lines by their IDs (e.g. 'victoria', 'central', '25').",
+    "line_lookup",
+    "Gets details for one or more TfL lines by their IDs, or all lines for a given mode. Valid modes: tube, bus, dlr, overground, elizabeth-line, national-rail, tflrail, tram, cable-car.",
     {
       ids: z
         .string()
+        .optional()
         .describe("Comma-separated line IDs (e.g. 'victoria,central,jubilee' or '25,73')"),
-    },
-    {
-      title: "Lines by IDs",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ ids }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(`/Line/${encodeURIComponent(ids)}`);
-          return data.map(formatLine).join("\n");
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_by_mode",
-    "Gets all lines serving a given transport mode (e.g. all tube lines, all bus lines).",
-    {
       modes: z
         .string()
+        .optional()
         .describe(
-          "Comma-separated transport modes (e.g. 'tube', 'bus', 'dlr', 'overground', 'elizabeth-line')",
+          "Comma-separated transport modes (e.g. 'tube', 'bus', 'dlr'). Use instead of ids to get all lines for a mode.",
         ),
     },
     {
-      title: "Lines by Mode",
+      title: "Line Lookup",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: true,
     },
-    async ({ modes }) => {
+    async ({ ids, modes }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(`/Line/Mode/${encodeURIComponent(modes)}`);
-          return `Lines for mode(s) "${modes}" (${data.length} total):\n\n${data.map(formatLine).join("\n")}`;
+          if (modes) {
+            const data = yield* client.request<Line[]>(`/Line/Mode/${encodeURIComponent(modes)}`);
+            return `Lines for mode(s) "${modes}" (${data.length} total):\n\n${data.map(formatLine).join("\n")}`;
+          }
+          const data = yield* client.request<Line[]>(`/Line/${encodeURIComponent(ids ?? "")}`);
+          return data.map(formatLine).join("\n");
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -254,12 +127,36 @@ export const registerLineTools = (
   // --- Status ---
   server.tool(
     "line_status",
-    "Gets current service status for one or more specific lines (e.g. 'Good Service', 'Minor Delays', 'Severe Delays', 'Suspended').",
+    "Gets current service status for TfL lines. Can query by line IDs, mode, severity level, or date range. Severity codes: 10=Good Service, 9=Reduced Service, 6=Severe Delays, 5=Part Closure, 4=Planned Closure, 2=Suspended, 0=Special Service. Service types: Regular, Night.",
     {
       ids: z
         .string()
-        .describe("Comma-separated line IDs to check (e.g. 'victoria,jubilee,central')"),
-      detail: z.boolean().optional().describe("If true, include detailed disruption information"),
+        .optional()
+        .describe(
+          "Comma-separated line IDs (e.g. 'victoria,jubilee'). Modes: tube, bus, dlr, overground, elizabeth-line",
+        ),
+      modes: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated modes (e.g. 'tube,dlr'). Use instead of ids to get all lines for a mode.",
+        ),
+      severity: z.coerce
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "Severity code: 10=Good Service, 9=Reduced Service, 6=Severe Delays, 5=Part Closure, 4=Planned Closure, 2=Suspended, 0=Special Service",
+        ),
+      startDate: z
+        .string()
+        .optional()
+        .describe("Start of date range, ISO 8601 (e.g. '2024-03-01T00:00:00'). Requires ids."),
+      endDate: z
+        .string()
+        .optional()
+        .describe("End of date range, ISO 8601 (e.g. '2024-03-07T23:59:59'). Requires ids."),
+      detail: z.boolean().optional().describe("Include detailed disruption info"),
     },
     {
       title: "Line Status",
@@ -268,114 +165,38 @@ export const registerLineTools = (
       idempotentHint: false,
       openWorldHint: true,
     },
-    async ({ ids, detail }) => {
+    async ({ ids, modes, severity, startDate, endDate, detail }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(`/Line/${encodeURIComponent(ids)}/Status`, {
-            detail,
-          });
+          if (severity !== undefined) {
+            const data = yield* client.request<Line[]>(`/Line/Status/${severity}`);
+            if (!data.length) return `No lines at severity level ${severity}.`;
+            return `Lines at severity ${severity}:\n\n${data.map(formatLine).join("\n")}`;
+          }
+          if (ids && startDate && endDate) {
+            const toIso = (d: string): string =>
+              d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : d;
+            const start = toIso(startDate);
+            const end = toIso(endDate);
+            const data = yield* client.request<Line[]>(
+              `/Line/${encodeURIComponent(ids)}/Status/${encodeURIComponent(start)}/to/${encodeURIComponent(end)}`,
+              { detail },
+            );
+            return `Status for ${ids} between ${start} and ${end}:\n\n${data.map(formatLine).join("\n")}`;
+          }
+          if (modes) {
+            const data = yield* client.request<Line[]>(
+              `/Line/Mode/${encodeURIComponent(modes)}/Status`,
+              { detail },
+            );
+            return `Status for ${modes} lines:\n\n${data.map(formatLine).join("\n")}`;
+          }
+          const data = yield* client.request<Line[]>(
+            `/Line/${encodeURIComponent(ids ?? "")}/Status`,
+            { detail },
+          );
           return `Current line status:\n\n${data.map(formatLine).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_status_by_mode",
-    "Gets current service status for all lines of a given mode (e.g. all tube lines, all DLR lines).",
-    {
-      modes: z
-        .string()
-        .describe("Comma-separated modes (e.g. 'tube', 'dlr', 'overground', 'elizabeth-line')"),
-      detail: z.boolean().optional().describe("If true, include detailed disruption reasons"),
-    },
-    {
-      title: "Line Status by Mode",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ modes, detail }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(
-            `/Line/Mode/${encodeURIComponent(modes)}/Status`,
-            { detail },
-          );
-          return `Status for ${modes} lines:\n\n${data.map(formatLine).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_status_by_severity",
-    "Gets all lines currently at a given severity level. Use line_meta_severity to get severity codes.",
-    {
-      severity: z.coerce
-        .number()
-        .int()
-        .describe(
-          "Severity level integer code. Use line_meta_severity to look up available codes.",
-        ),
-    },
-    {
-      title: "Line Status by Severity",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ severity }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(`/Line/Status/${severity}`);
-          if (!data.length) return `No lines at severity level ${severity}.`;
-          return `Lines at severity ${severity}:\n\n${data.map(formatLine).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_status_by_date_range",
-    "Gets service status for specific lines over a date range (useful for checking historical disruptions or planned closures).",
-    {
-      ids: z.string().describe("Comma-separated line IDs (e.g. 'victoria,jubilee')"),
-      startDate: z.string().describe("Start date in ISO 8601 format (e.g. '2024-03-01T00:00:00')"),
-      endDate: z.string().describe("End date in ISO 8601 format (e.g. '2024-03-07T23:59:59')"),
-      detail: z.boolean().optional().describe("Include detailed disruption info"),
-    },
-    {
-      title: "Line Status by Date Range",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ ids, startDate, endDate, detail }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const toIso = (d: string): string =>
-            d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : d;
-          const start = toIso(startDate);
-          const end = toIso(endDate);
-          const data = yield* client.request<Line[]>(
-            `/Line/${encodeURIComponent(ids)}/Status/${encodeURIComponent(start)}/to/${encodeURIComponent(end)}`,
-            { detail },
-          );
-          return `Status for ${ids} between ${start} and ${end}:\n\n${data.map(formatLine).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -386,9 +207,15 @@ export const registerLineTools = (
   // --- Disruptions ---
   server.tool(
     "line_disruptions",
-    "Gets active disruptions for specific lines.",
+    "Gets active disruptions for specific lines or all lines of a given mode.",
     {
-      ids: z.string().describe("Comma-separated line IDs (e.g. 'central,district')"),
+      ids: z.string().optional().describe("Comma-separated line IDs (e.g. 'central,district')"),
+      modes: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated modes (e.g. 'tube', 'bus', 'overground'). Use instead of ids to get disruptions for all lines of a mode.",
+        ),
     },
     {
       title: "Line Disruptions",
@@ -397,12 +224,19 @@ export const registerLineTools = (
       idempotentHint: false,
       openWorldHint: true,
     },
-    async ({ ids }) => {
+    async ({ ids, modes }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (modes) {
+            const data = yield* client.request<Disruption[]>(
+              `/Line/Mode/${encodeURIComponent(modes)}/Disruption`,
+            );
+            if (!data.length) return `No active disruptions for mode(s): ${modes}`;
+            return `Disruptions for ${modes}:\n\n${data.map(formatDisruption).join("\n---\n")}`;
+          }
           const data = yield* client.request<Disruption[]>(
-            `/Line/${encodeURIComponent(ids)}/Disruption`,
+            `/Line/${encodeURIComponent(ids ?? "")}/Disruption`,
           );
           if (!data.length) return `No active disruptions for lines: ${ids}`;
           return `Disruptions for ${ids}:\n\n${data.map(formatDisruption).join("\n---\n")}`;
@@ -413,41 +247,18 @@ export const registerLineTools = (
     },
   );
 
-  server.tool(
-    "line_disruptions_by_mode",
-    "Gets all active disruptions across all lines of a given mode.",
-    {
-      modes: z.string().describe("Comma-separated modes (e.g. 'tube', 'bus', 'overground')"),
-    },
-    {
-      title: "Line Disruptions by Mode",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ modes }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Disruption[]>(
-            `/Line/Mode/${encodeURIComponent(modes)}/Disruption`,
-          );
-          if (!data.length) return `No active disruptions for mode(s): ${modes}`;
-          return `Disruptions for ${modes}:\n\n${data.map(formatDisruption).join("\n---\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
   // --- Routes ---
   server.tool(
     "line_routes",
-    "Gets all valid routes for specific lines, including originating and terminating stop names.",
+    "Gets valid routes for specific lines, all lines of a mode, or all TfL lines. Service types: Regular, Night.",
     {
-      ids: z.string().describe("Comma-separated line IDs (e.g. 'victoria,elizabeth')"),
+      ids: z.string().optional().describe("Comma-separated line IDs (e.g. 'victoria,elizabeth')"),
+      modes: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated modes (e.g. 'tube,overground'). Use instead of ids to get routes for all lines of a mode.",
+        ),
       serviceTypes: z
         .string()
         .optional()
@@ -460,7 +271,7 @@ export const registerLineTools = (
       idempotentHint: true,
       openWorldHint: true,
     },
-    async ({ ids, serviceTypes }) => {
+    async ({ ids, modes, serviceTypes }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
@@ -474,20 +285,35 @@ export const registerLineTools = (
             serviceType?: string;
           };
           type LineWithRoutes = Line & { routeSections?: RouteSection[] };
-          const data = yield* client.request<LineWithRoutes[]>(
-            `/Line/${encodeURIComponent(ids)}/Route`,
-            { serviceTypes },
-          );
-          if (!data.length) return `No routes found for lines: ${ids}`;
-          const sections = data.flatMap((line) =>
-            (line.routeSections ?? []).map(
-              (r) =>
-                `${line.name ?? line.id ?? "?"} (${r.serviceType ?? "Regular"}) ${r.direction ?? "?"}: ${r.originationName ?? r.originator ?? "?"} → ${r.destinationName ?? r.destination ?? "?"}`,
-            ),
-          );
-          return sections.length
-            ? `Routes for ${ids} (${sections.length} sections):\n\n${sections.join("\n")}`
-            : `Lines found but no route sections for: ${ids}`;
+          if (modes) {
+            const data = yield* client.request<Line[]>(
+              `/Line/Mode/${encodeURIComponent(modes)}/Route`,
+              { serviceTypes },
+            );
+            if (!data.length) return `No routes found for mode(s): ${modes}`;
+            const lines = data.map(
+              (l) => `${l.name ?? l.id ?? "?"} (${l.modeName ?? "?"}) — ID: ${l.id ?? "?"}`,
+            );
+            return `Routes for mode(s) "${modes}" (${data.length} lines):\n\n${lines.join("\n")}`;
+          }
+          if (ids) {
+            const data = yield* client.request<LineWithRoutes[]>(
+              `/Line/${encodeURIComponent(ids)}/Route`,
+              { serviceTypes },
+            );
+            if (!data.length) return `No routes found for lines: ${ids}`;
+            const sections = data.flatMap((line) =>
+              (line.routeSections ?? []).map(
+                (r) =>
+                  `${line.name ?? line.id ?? "?"} (${r.serviceType ?? "Regular"}) ${r.direction ?? "?"}: ${r.originationName ?? r.originator ?? "?"} → ${r.destinationName ?? r.destination ?? "?"}`,
+              ),
+            );
+            return sections.length
+              ? `Routes for ${ids} (${sections.length} sections):\n\n${sections.join("\n")}`
+              : `Lines found but no route sections for: ${ids}`;
+          }
+          const data = yield* client.request<Line[]>("/Line/Route", { serviceTypes });
+          return `All TfL routes (${data.length} lines):\n\n${data.map((l) => `${l.name ?? l.id ?? "??"} (${l.modeName ?? "?"})`).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -542,71 +368,6 @@ export const registerLineTools = (
             return `Branch ${seq.branchId ?? i + 1} (${seq.direction ?? direction}): ${stops}`;
           });
           return `Stop sequence for ${data.lineName ?? id} (${direction}):\n\n${sections.join("\n\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_routes_by_mode",
-    "Gets all routes for all lines of a given mode.",
-    {
-      modes: z.string().describe("Comma-separated modes (e.g. 'tube,overground')"),
-      serviceTypes: z.string().optional().describe("Filter by service type"),
-    },
-    {
-      title: "Line Routes by Mode",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ modes, serviceTypes }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Line[]>(
-            `/Line/Mode/${encodeURIComponent(modes)}/Route`,
-            { serviceTypes },
-          );
-          if (!data.length) return `No routes found for mode(s): ${modes}`;
-          const lines = data.map(
-            (l) => `${l.name ?? l.id ?? "?"} (${l.modeName ?? "?"}) — ID: ${l.id ?? "?"}`,
-          );
-          return `Routes for mode(s) "${modes}" (${data.length} lines):\n\n${lines.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "line_all_routes",
-    "Gets all valid routes for all TfL lines.",
-    {
-      serviceTypes: z
-        .string()
-        .optional()
-        .describe("Filter by service type (e.g. 'Regular' or 'Night')"),
-    },
-    {
-      title: "All Line Routes",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ serviceTypes }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Line[]>("/Line/Route", {
-            serviceTypes,
-          });
-          return `All TfL routes (${data.length} lines):\n\n${data.map((l) => `${l.name ?? l.id ?? "??"} (${l.modeName ?? "?"})`).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/mode.ts
+++ b/src/mcp/tools/mode.ts
@@ -11,35 +11,8 @@ export const registerModeTools = (
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
   server.tool(
-    "mode_active_service_types",
-    "Returns the active service types for each transport mode (e.g. whether Night Tube is currently running).",
-    {},
-    {
-      title: "Active Service Types",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Array<{ mode?: string; serviceType?: string }>>(
-            "/Mode/ActiveServiceTypes",
-          );
-          const rows = data.map((s) => `${s.mode ?? "?"}: ${s.serviceType ?? "?"}`);
-          return `Active service types:\n\n${rows.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
     "mode_arrivals",
-    "Gets the next arrival predictions for all stops of a given transport mode.",
+    "Gets the next arrival predictions for all stops of a given transport mode. Valid modes: tube, bus, dlr, overground, elizabeth-line, tram, cable-car.",
     {
       mode: z
         .string()

--- a/src/mcp/tools/occupancy.ts
+++ b/src/mcp/tools/occupancy.ts
@@ -45,40 +45,16 @@ export const registerOccupancyTools = (
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
   server.tool(
-    "occupancy_car_parks_all",
-    "Gets live occupancy (free spaces) for all TfL car parks that provide occupancy data.",
-    {},
-    {
-      title: "Car Park Occupancy",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<CarPark[]>("/Occupancy/CarPark");
-          if (!data.length) return "No car park occupancy data available.";
-          return `Car park occupancy (${data.length} parks):\n\n${data.map(formatCarPark).join("\n\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "occupancy_car_park_by_id",
-    "Gets live occupancy for a specific TfL car park by its ID.",
+    "occupancy_car_parks",
+    "Gets live occupancy (free spaces) for TfL car parks. Omit id to get all car parks that provide occupancy data.",
     {
       id: z
         .string()
-        .describe("Car park ID (e.g. 'CarParks_800491'). Use occupancy_car_parks_all to find IDs."),
+        .optional()
+        .describe("Car park ID (e.g. 'CarParks_800491'). Omit to get all car parks."),
     },
     {
-      title: "Car Park Occupancy by ID",
+      title: "Car Park Occupancy",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: false,
@@ -88,10 +64,15 @@ export const registerOccupancyTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<CarPark>(
-            `/Occupancy/CarPark/${encodeURIComponent(id)}`,
-          );
-          return formatCarPark(data);
+          if (id) {
+            const data = yield* client.request<CarPark>(
+              `/Occupancy/CarPark/${encodeURIComponent(id)}`,
+            );
+            return formatCarPark(data);
+          }
+          const data = yield* client.request<CarPark[]>("/Occupancy/CarPark");
+          if (!data.length) return "No car park occupancy data available.";
+          return `Car park occupancy (${data.length} parks):\n\n${data.map(formatCarPark).join("\n\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -136,45 +117,18 @@ export const registerOccupancyTools = (
   );
 
   server.tool(
-    "occupancy_charge_connectors_all",
-    "Gets live availability status for all EV charge connectors managed by TfL.",
-    {},
-    {
-      title: "EV Charge Connector Availability",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<ChargeConnector[]>("/Occupancy/ChargeConnector");
-          if (!data.length) return "No charge connector data available.";
-          const formatted = data.map(
-            (c) => `${c.sourceSystemPlaceId ?? c.id ?? "?"}: ${c.status ?? "?"}`,
-          );
-          return `Charge connector statuses (${data.length} connectors):\n\n${formatted.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "occupancy_charge_connectors_by_ids",
-    "Gets live availability status for specific EV charge connectors by their source system IDs.",
+    "occupancy_charge_connectors",
+    "Gets live availability status for TfL EV charge connectors. Omit ids to get all connectors.",
     {
       ids: z
         .string()
+        .optional()
         .describe(
-          "Comma-separated charge connector source system IDs. Use occupancy_charge_connectors_all to find IDs.",
+          "Comma-separated charge connector source system IDs. Omit to get all connectors.",
         ),
     },
     {
-      title: "EV Charge Connectors by ID",
+      title: "EV Charge Connector Availability",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: false,
@@ -184,13 +138,21 @@ export const registerOccupancyTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<ChargeConnector[]>(
-            `/Occupancy/ChargeConnector/${encodeURIComponent(ids)}`,
-          );
+          if (ids) {
+            const data = yield* client.request<ChargeConnector[]>(
+              `/Occupancy/ChargeConnector/${encodeURIComponent(ids)}`,
+            );
+            const formatted = data.map(
+              (c) => `${c.sourceSystemPlaceId ?? c.id ?? "?"}: ${c.status ?? "?"}`,
+            );
+            return `Charge connector statuses:\n\n${formatted.join("\n")}`;
+          }
+          const data = yield* client.request<ChargeConnector[]>("/Occupancy/ChargeConnector");
+          if (!data.length) return "No charge connector data available.";
           const formatted = data.map(
             (c) => `${c.sourceSystemPlaceId ?? c.id ?? "?"}: ${c.status ?? "?"}`,
           );
-          return `Charge connector statuses:\n\n${formatted.join("\n")}`;
+          return `Charge connector statuses (${data.length} connectors):\n\n${formatted.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/place.ts
+++ b/src/mcp/tools/place.ts
@@ -22,7 +22,7 @@ export const registerPlaceTools = (
 ) => {
   server.tool(
     "place_search",
-    "Search for TfL places (stations, stops, landmarks) by name.",
+    "Search for TfL places (stations, stops, landmarks) by name. Valid place types include: StopPoint, NaptanMetroStation, NaptanRailStation, CarPark, Airport, BikePoint, and others.",
     {
       name: z
         .string()
@@ -32,7 +32,7 @@ export const registerPlaceTools = (
         .string()
         .optional()
         .describe(
-          "Comma-separated place types to filter by. Use place_meta_types to get available types.",
+          "Comma-separated place types to filter by (e.g. 'StopPoint,NaptanMetroStation').",
         ),
     },
     {
@@ -132,38 +132,10 @@ export const registerPlaceTools = (
   );
 
   server.tool(
-    "place_meta_types",
-    "Gets the list of valid TfL place types.",
-    {},
-    {
-      title: "Place Meta Types",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Place/Meta/PlaceTypes");
-          return `Place types:\n\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
     "place_by_type",
-    "Gets all places of a given type.",
+    "Gets all places of a given type. Valid types: StopPoint, NaptanMetroStation, NaptanRailStation, CarPark, Airport, BikePoint, and others.",
     {
-      types: z
-        .string()
-        .describe(
-          "Comma-separated place types (e.g. 'CarPark,Airport'). Use place_meta_types to list valid types.",
-        ),
+      types: z.string().describe("Comma-separated place types (e.g. 'CarPark,Airport')."),
     },
     {
       title: "Places by Type",

--- a/src/mcp/tools/road.ts
+++ b/src/mcp/tools/road.ts
@@ -53,77 +53,30 @@ export const registerRoadTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
-  // --- Meta ---
   server.tool(
-    "road_meta_categories",
-    "Gets the list of valid road disruption category names.",
-    {},
+    "road_lookup",
+    "Gets status for roads on the TfL Road Network (TLRN). Omit ids to get all roads.",
     {
-      title: "Road Disruption Categories",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
+      ids: z
+        .string()
+        .optional()
+        .describe("Comma-separated road IDs (e.g. 'A1,A2'). Omit to get all roads on the TLRN."),
     },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Road/Meta/Categories");
-          return `Road disruption categories:\n\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "road_meta_severities",
-    "Gets the list of valid road disruption severity levels.",
-    {},
     {
-      title: "Road Disruption Severities",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data =
-            yield* client.request<
-              Array<{ description?: string; severityLevel?: number; modeName?: string }>
-            >("/Road/Meta/Severities");
-          const rows = data.map(
-            (s) =>
-              `${s.description ?? "?"} (severityLevel: ${s.severityLevel ?? "?"}, mode: ${s.modeName ?? "?"})`,
-          );
-          return `Road disruption severities:\n\n${rows.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "road_all",
-    "Gets status for all roads on the TfL Road Network (TLRN).",
-    {},
-    {
-      title: "All Roads Status",
+      title: "Road Lookup",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: false,
       openWorldHint: true,
     },
-    async () => {
+    async ({ ids }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (ids) {
+            const data = yield* client.request<Road[]>(`/Road/${encodeURIComponent(ids)}`);
+            return `Road status:\n\n${data.map(formatRoad).join("\n\n")}`;
+          }
           const data = yield* client.request<Road[]>("/Road");
           return `Road network status (${data.length} roads):\n\n${data.map(formatRoad).join("\n\n")}`;
         }),
@@ -134,40 +87,13 @@ export const registerRoadTools = (
   );
 
   server.tool(
-    "road_by_ids",
-    "Gets status for specific roads on the TLRN by their IDs.",
+    "road_disruptions",
+    "Gets active disruptions on specific TLRN roads, or all disruptions across the entire network. Valid disruption categories: roadworks, incidents, streetworks, plannedworks, events, trafficflow.",
     {
       ids: z
         .string()
-        .describe(
-          "Comma-separated road IDs (e.g. 'A1,A2'). Use road_all to discover available IDs.",
-        ),
-    },
-    {
-      title: "Road Status by ID",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ ids }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<Road[]>(`/Road/${encodeURIComponent(ids)}`);
-          return `Road status:\n\n${data.map(formatRoad).join("\n\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "road_disruptions",
-    "Gets active disruptions on specific TLRN roads.",
-    {
-      ids: z.string().describe("Comma-separated road IDs (e.g. 'A1,A2')"),
+        .optional()
+        .describe("Comma-separated road IDs (e.g. 'A1,A2'). Omit to get all TLRN disruptions."),
       stripContent: z
         .boolean()
         .optional()
@@ -176,7 +102,10 @@ export const registerRoadTools = (
         .string()
         .optional()
         .describe("Comma-separated severity filter (e.g. 'Serious,Severe')"),
-      categories: z.string().optional().describe("Comma-separated category filter"),
+      categories: z
+        .string()
+        .optional()
+        .describe("Comma-separated category filter (e.g. 'roadworks,incidents')"),
       closures: z.boolean().optional().describe("If true, only return closures"),
     },
     {
@@ -190,45 +119,14 @@ export const registerRoadTools = (
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
-          const data = yield* client.request<RoadDisruption[]>(
-            `/Road/${encodeURIComponent(ids)}/Disruption`,
-            { stripContent, severities, categories, closures },
-          );
-          if (!data.length) return `No active disruptions for roads: ${ids}`;
-          return `Disruptions on ${ids}:\n\n${data.map(formatDisruption).join("\n---\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "road_disruptions_all",
-    "Gets all active road disruptions across the entire TLRN.",
-    {
-      stripContent: z
-        .boolean()
-        .optional()
-        .describe("If true, strip HTML from disruption descriptions"),
-      severities: z
-        .string()
-        .optional()
-        .describe("Comma-separated severity filter (e.g. 'Serious,Severe')"),
-      categories: z.string().optional().describe("Comma-separated category filter"),
-      closures: z.boolean().optional().describe("If true, only return closures"),
-    },
-    {
-      title: "All Road Disruptions",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ stripContent, severities, categories, closures }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
+          if (ids) {
+            const data = yield* client.request<RoadDisruption[]>(
+              `/Road/${encodeURIComponent(ids)}/Disruption`,
+              { stripContent, severities, categories, closures },
+            );
+            if (!data.length) return `No active disruptions for roads: ${ids}`;
+            return `Disruptions on ${ids}:\n\n${data.map(formatDisruption).join("\n---\n")}`;
+          }
           const data = yield* client.request<RoadDisruption[]>("/Road/all/Disruption", {
             stripContent,
             severities,

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -35,12 +35,18 @@ export const registerSearchTools = (
 ) => {
   server.tool(
     "search",
-    "Search the TfL site and data for any query — finds stations, stops, lines, places, and other TfL content. Returns up to 100 results.",
+    "Search the TfL site and data. Use scope='bus_schedules' to search for bus schedule documents. Returns up to 100 results.",
     {
       query: z
         .string()
         .min(1)
         .describe("Search term (e.g. 'Victoria', 'Waterloo', 'Northern line', 'bus 25')"),
+      scope: z
+        .enum(["general", "bus_schedules"])
+        .optional()
+        .describe(
+          "Search scope: 'general' (default) for stations/stops/lines/places, or 'bus_schedules' to search for bus route schedule documents.",
+        ),
     },
     {
       title: "TfL Search",
@@ -49,116 +55,22 @@ export const registerSearchTools = (
       idempotentHint: true,
       openWorldHint: true,
     },
-    async ({ query }) => {
+    async ({ query, scope }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (scope === "bus_schedules") {
+            const data = yield* client.request<SearchResponse>("/Search/BusSchedules", { query });
+            const matches = data.matches ?? [];
+            if (!matches.length) return `No bus schedule documents found for "${query}".`;
+            const header = `Bus schedule results for "${query}" (${matches.length} of ${data.total ?? "?"}):`;
+            return `${header}\n\n${matches.map(formatMatch).join("\n")}`;
+          }
           const data = yield* client.request<SearchResponse>("/Search", { query });
           const matches = data.matches ?? [];
           if (!matches.length) return `No results found for "${query}".`;
           const header = `Search results for "${query}" (${matches.length} of ${data.total ?? "?"}):`;
           return `${header}\n\n${matches.map(formatMatch).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "search_bus_schedules",
-    "Searches for bus schedule documents on TfL's S3 storage for a given bus route number.",
-    {
-      query: z.string().describe("Bus route number or name to search for (e.g. '25', '73', 'N25')"),
-    },
-    {
-      title: "Bus Schedule Search",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ query }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<SearchResponse>("/Search/BusSchedules", { query });
-          const matches = data.matches ?? [];
-          if (!matches.length) return `No bus schedule documents found for "${query}".`;
-          const header = `Bus schedule results for "${query}" (${matches.length} of ${data.total ?? "?"}):`;
-          return `${header}\n\n${matches.map(formatMatch).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "search_meta_categories",
-    "Gets the available search categories that can be used to filter TfL search results.",
-    {},
-    {
-      title: "Search Meta Categories",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Search/Meta/Categories");
-          return `Search categories (${data.length}):\n\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "search_meta_providers",
-    "Gets the available search provider names used by the TfL search API.",
-    {},
-    {
-      title: "Search Meta Providers",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Search/Meta/SearchProviders");
-          return `Search providers (${data.length}):\n\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "search_meta_sorts",
-    "Gets the available sorting options for TfL search results.",
-    {},
-    {
-      title: "Search Meta Sorts",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/Search/Meta/Sorts");
-          return `Search sort options (${data.length}):\n\n${data.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);

--- a/src/mcp/tools/stop-point.ts
+++ b/src/mcp/tools/stop-point.ts
@@ -31,89 +31,6 @@ export const registerStopPointTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
 ) => {
-  // --- Meta ---
-  server.tool(
-    "stoppoint_meta_modes",
-    "Gets the list of all transport modes available at TfL stop points.",
-    {},
-    {
-      title: "StopPoint Meta Modes",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data =
-            yield* client.request<Array<{ modeName?: string; isTflService?: boolean }>>(
-              "/StopPoint/Meta/Modes",
-            );
-          const modes = data.map((m) => `${m.modeName ?? "?"} (TfL: ${m.isTflService ?? false})`);
-          return `StopPoint modes:\n\n${modes.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_meta_stop_types",
-    "Gets all valid stop point types (e.g. NaptanMetroStation, NaptanPublicBusCoachTram, NaptanRailStation).",
-    {},
-    {
-      title: "StopPoint Meta Stop Types",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<string[]>("/StopPoint/Meta/StopTypes");
-          return `Stop point types:\n\n${data.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_meta_categories",
-    "Gets the list of available additional information categories for stop points.",
-    {},
-    {
-      title: "StopPoint Meta Categories",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async () => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<
-            Array<{ category?: string; availableKeys?: string[] }>
-          >("/StopPoint/Meta/Categories");
-          const lines = data.map((c) => {
-            const keys = c.availableKeys?.join(", ") ?? "none";
-            return `${c.category ?? "?"}: ${keys}`;
-          });
-          return `StopPoint categories (${data.length}):\n\n${lines.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
   // --- Lookup ---
   server.tool(
     "stoppoint_search",
@@ -216,6 +133,58 @@ export const registerStopPointTools = (
   );
 
   server.tool(
+    "stoppoint_lookup",
+    "Gets stop points by transport mode or by stop type. Valid stop types: NaptanMetroStation, NaptanPublicBusCoachTram, NaptanRailStation, NaptanFerryPort, NaptanAirport. Supports pagination.",
+    {
+      modes: z
+        .string()
+        .optional()
+        .describe("Comma-separated modes (e.g. 'tube', 'dlr', 'overground')"),
+      types: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated stop types (e.g. 'NaptanMetroStation'). Use instead of modes to filter by stop type.",
+        ),
+      page: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Page number for pagination (default: 1)"),
+    },
+    {
+      title: "StopPoint Lookup",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async ({ modes, types, page }) => {
+      const result = await runtime.runPromiseExit(
+        Effect.gen(function* () {
+          const client = yield* TflClient;
+          if (types) {
+            const path = page
+              ? `/StopPoint/Type/${encodeURIComponent(types)}/page/${page}`
+              : `/StopPoint/Type/${encodeURIComponent(types)}`;
+            const data = yield* client.request<StopPoint[]>(path);
+            return `Stop points of type "${types}" (${data.length}):\n\n${data.map(formatStop).join("\n")}`;
+          }
+          const raw = yield* client.request<StopPoint | StopPoint[]>(
+            `/StopPoint/Mode/${encodeURIComponent(modes ?? "")}`,
+            { page },
+          );
+          const data = Array.isArray(raw) ? raw : [raw];
+          return `Stop points for mode(s) "${modes}" (page ${page ?? 1}, ${data.length} results):\n\n${data.map(formatStop).join("\n")}`;
+        }),
+      );
+      if (result._tag === "Failure") return formatError(result.cause);
+      return formatSuccess(result.value);
+    },
+  );
+
+  server.tool(
     "stoppoint_by_sms",
     "Gets a stop point by its 5-digit SMS bus stop code (used for TfL's SMS arrival checker service).",
     {
@@ -247,14 +216,14 @@ export const registerStopPointTools = (
 
   server.tool(
     "stoppoint_by_geo",
-    "Gets stop points within a radius of given coordinates, filtered by stop type.",
+    "Gets stop points within a radius of given coordinates, filtered by stop type. Valid stop types: NaptanMetroStation, NaptanPublicBusCoachTram, NaptanRailStation, NaptanFerryPort, NaptanAirport.",
     {
       lat: z.number().describe("Latitude"),
       lon: z.number().describe("Longitude"),
       stopTypes: z
         .string()
         .describe(
-          "Comma-separated stop type(s) (e.g. 'NaptanMetroStation,NaptanPublicBusCoachTram'). Use stoppoint_meta_stop_types for available types.",
+          "Comma-separated stop type(s) (e.g. 'NaptanMetroStation,NaptanPublicBusCoachTram').",
         ),
       radius: z
         .number()
@@ -317,76 +286,6 @@ export const registerStopPointTools = (
   );
 
   server.tool(
-    "stoppoint_by_mode",
-    "Gets all stop points filtered by transport mode. Supports pagination.",
-    {
-      modes: z.string().describe("Comma-separated modes (e.g. 'tube', 'dlr', 'overground')"),
-      page: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe("Page number for pagination (default: 1)"),
-    },
-    {
-      title: "StopPoints by Mode",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ modes, page }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const raw = yield* client.request<StopPoint | StopPoint[]>(
-            `/StopPoint/Mode/${encodeURIComponent(modes)}`,
-            { page },
-          );
-          const data = Array.isArray(raw) ? raw : [raw];
-          return `Stop points for mode(s) "${modes}" (page ${page ?? 1}, ${data.length} results):\n\n${data.map(formatStop).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_by_type",
-    "Gets all stop points of a specific type, with optional pagination.",
-    {
-      types: z
-        .string()
-        .describe(
-          "Comma-separated stop types (e.g. 'NaptanMetroStation'). Use stoppoint_meta_stop_types to list valid types.",
-        ),
-      page: z.number().int().optional().describe("Page number for large result sets"),
-    },
-    {
-      title: "StopPoints by Type",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ types, page }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const path = page
-            ? `/StopPoint/Type/${encodeURIComponent(types)}/page/${page}`
-            : `/StopPoint/Type/${encodeURIComponent(types)}`;
-          const data = yield* client.request<StopPoint[]>(path);
-          return `Stop points of type "${types}" (${data.length}):\n\n${data.map(formatStop).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
     "stoppoint_service_types",
     "Gets the service types (Regular, Night) available at a specific stop point.",
     {
@@ -423,13 +322,28 @@ export const registerStopPointTools = (
   // --- Arrivals ---
   server.tool(
     "stoppoint_arrivals",
-    "Gets live arrival predictions for all lines at a given stop point. The most useful real-time departure board tool.",
+    "Gets live arrival predictions (and optionally departures) at a given stop point. Pass includeDepartures=true for Overground and Elizabeth line departure boards.",
     {
       id: z
         .string()
         .describe(
           "Stop point Naptan ID (e.g. '940GZZLUVIC' for Victoria tube). Use stoppoint_search to find IDs.",
         ),
+      includeDepartures: z
+        .boolean()
+        .optional()
+        .describe("If true, return arrival/departure data (Overground and Elizabeth line only)"),
+      lineIds: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated line IDs to filter (used with includeDepartures, e.g. 'london-overground,elizabeth')",
+        ),
+      numberOfArrivals: z
+        .number()
+        .int()
+        .optional()
+        .describe("Maximum number of arrivals to return"),
     },
     {
       title: "StopPoint Arrivals",
@@ -438,65 +352,40 @@ export const registerStopPointTools = (
       idempotentHint: false,
       openWorldHint: true,
     },
-    async ({ id }) => {
+    async ({ id, includeDepartures, lineIds, numberOfArrivals }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (includeDepartures) {
+            const data = yield* client.request<
+              Array<{
+                stationName?: string;
+                lineName?: string;
+                platformName?: string;
+                destinationName?: string;
+                scheduledTimeOfArrival?: string;
+                scheduledTimeOfDeparture?: string;
+                estimatedTimeOfArrival?: string;
+                estimatedTimeOfDeparture?: string;
+              }>
+            >(`/StopPoint/${encodeURIComponent(id)}/ArrivalDepartures`, { lineIds });
+            if (!data.length) return `No arrivals/departures at stop ${id}.`;
+            const lines = data.map((d) => {
+              const dest = d.destinationName ?? "?";
+              const platform = d.platformName ? ` (${d.platformName})` : "";
+              const arr = d.estimatedTimeOfArrival ?? d.scheduledTimeOfArrival ?? "?";
+              const dep = d.estimatedTimeOfDeparture ?? d.scheduledTimeOfDeparture ?? "?";
+              return `  ${d.lineName ?? "?"} → ${dest}${platform} — arr: ${arr} dep: ${dep}`;
+            });
+            return `Arrival/Departures at ${data[0]?.stationName ?? id}:\n${lines.join("\n")}`;
+          }
           const data = yield* client.request<ArrivalPrediction[]>(
             `/StopPoint/${encodeURIComponent(id)}/Arrivals`,
           );
           if (!data.length) return `No arrivals currently predicted at stop ${id}.`;
           const sorted = [...data].sort((a, b) => (a.timeToStation ?? 0) - (b.timeToStation ?? 0));
-          return `Arrivals at ${data[0]?.stationName ?? id}:\n${sorted.map(formatArrival).join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_arrival_departures",
-    "Gets live arrival AND departure predictions for a stop point (Overground and Elizabeth line only).",
-    {
-      id: z.string().describe("Stop point Naptan ID"),
-      lineIds: z
-        .string()
-        .optional()
-        .describe("Comma-separated line IDs to filter (e.g. 'london-overground,elizabeth')"),
-    },
-    {
-      title: "StopPoint Arrival/Departures",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ id, lineIds }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<
-            Array<{
-              stationName?: string;
-              lineName?: string;
-              platformName?: string;
-              destinationName?: string;
-              scheduledTimeOfArrival?: string;
-              scheduledTimeOfDeparture?: string;
-              estimatedTimeOfArrival?: string;
-              estimatedTimeOfDeparture?: string;
-            }>
-          >(`/StopPoint/${encodeURIComponent(id)}/ArrivalDepartures`, { lineIds });
-          if (!data.length) return `No arrivals/departures at stop ${id}.`;
-          const lines = data.map((d) => {
-            const dest = d.destinationName ?? "?";
-            const platform = d.platformName ? ` (${d.platformName})` : "";
-            const arr = d.estimatedTimeOfArrival ?? d.scheduledTimeOfArrival ?? "?";
-            const dep = d.estimatedTimeOfDeparture ?? d.scheduledTimeOfDeparture ?? "?";
-            return `  ${d.lineName ?? "?"} → ${dest}${platform} — arr: ${arr} dep: ${dep}`;
-          });
-          return `Arrival/Departures at ${data[0]?.stationName ?? id}:\n${lines.join("\n")}`;
+          const limited = numberOfArrivals ? sorted.slice(0, numberOfArrivals) : sorted;
+          return `Arrivals at ${data[0]?.stationName ?? id}:\n${limited.map(formatArrival).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -507,18 +396,27 @@ export const registerStopPointTools = (
   // --- Disruptions ---
   server.tool(
     "stoppoint_disruptions",
-    "Gets all active disruptions at one or more stop points.",
+    "Gets active disruptions at specific stop points or all disrupted stops for a given mode.",
     {
-      ids: z.string().describe("Comma-separated stop point Naptan IDs"),
-      getFamily: z.boolean().optional().describe("If true, include disruptions for child stops"),
+      ids: z.string().optional().describe("Comma-separated stop point Naptan IDs"),
+      modes: z
+        .string()
+        .optional()
+        .describe(
+          "Comma-separated modes (e.g. 'tube,dlr'). Use instead of ids to get all disrupted stops for a mode.",
+        ),
       includeRouteBlockedStops: z
         .boolean()
         .optional()
         .describe("If true, include stops where the route is blocked"),
+      getFamily: z
+        .boolean()
+        .optional()
+        .describe("If true, include disruptions for child stops (used with ids)"),
       flattenResponse: z
         .boolean()
         .optional()
-        .describe("If true, return a flat list rather than nested structure"),
+        .describe("If true, return a flat list rather than nested structure (used with ids)"),
     },
     {
       title: "StopPoint Disruptions",
@@ -527,10 +425,18 @@ export const registerStopPointTools = (
       idempotentHint: false,
       openWorldHint: true,
     },
-    async ({ ids, getFamily, includeRouteBlockedStops, flattenResponse }) => {
+    async ({ ids, modes, includeRouteBlockedStops, getFamily, flattenResponse }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (modes) {
+            const data = yield* client.request<StopPoint[]>(
+              `/StopPoint/Mode/${encodeURIComponent(modes)}/Disruption`,
+              { includeRouteBlockedStops },
+            );
+            if (!data.length) return `No disrupted stops for mode(s): ${modes}`;
+            return `Disrupted stops for ${modes} (${data.length}):\n\n${data.map(formatStop).join("\n")}`;
+          }
           const data = yield* client.request<
             Array<{
               category?: string;
@@ -542,7 +448,7 @@ export const registerStopPointTools = (
               affectedRoutes?: Array<{ name?: string }>;
               affectedStops?: Array<{ commonName?: string }>;
             }>
-          >(`/StopPoint/${encodeURIComponent(ids)}/Disruption`, {
+          >(`/StopPoint/${encodeURIComponent(ids ?? "")}/Disruption`, {
             getFamily,
             includeRouteBlockedStops,
             flattenResponse,
@@ -562,42 +468,6 @@ export const registerStopPointTools = (
             return parts.join("\n");
           });
           return `Disruptions at ${ids} (${data.length}):\n\n${lines.join("\n---\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_disruptions_by_mode",
-    "Gets all disrupted stop points for a given transport mode.",
-    {
-      modes: z.string().describe("Comma-separated modes (e.g. 'tube,dlr')"),
-      includeRouteBlockedStops: z
-        .boolean()
-        .optional()
-        .describe("If true, include route-blocked stops"),
-    },
-    {
-      title: "StopPoint Disruptions by Mode",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    async ({ modes, includeRouteBlockedStops }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<StopPoint[]>(
-            `/StopPoint/Mode/${encodeURIComponent(modes)}/Disruption`,
-            {
-              includeRouteBlockedStops,
-            },
-          );
-          if (!data.length) return `No disrupted stops for mode(s): ${modes}`;
-          return `Disrupted stops for ${modes} (${data.length}):\n\n${data.map(formatStop).join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);
@@ -767,107 +637,76 @@ export const registerStopPointTools = (
 
   // --- Associated places ---
   server.tool(
-    "stoppoint_car_parks",
-    "Gets car parks associated with a given stop point (station).",
-    {
-      stopPointId: z.string().describe("Stop point Naptan ID"),
-    },
-    {
-      title: "StopPoint Car Parks",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ stopPointId }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<
-            Array<{
-              id?: string;
-              name?: string;
-              carParkId?: string;
-              accessPoints?: Array<{ name?: string }>;
-              facilities?: Array<{ name?: string; description?: string; paymentMethods?: string }>;
-            }>
-          >(`/StopPoint/${encodeURIComponent(stopPointId)}/CarParks`);
-          if (!data.length) return `No car parks found near stop ${stopPointId}.`;
-          const lines = data.map((cp) => {
-            const id = cp.carParkId ?? cp.id ?? "?";
-            const name = cp.name ?? id;
-            const spaces =
-              cp.facilities?.map((f) => `${f.name ?? "?"}: ${f.description ?? "?"}`).join(", ") ??
-              "details unavailable";
-            return `${name} (${id}) — ${spaces}`;
-          });
-          return `Car parks near stop ${stopPointId} (${data.length}):\n\n${lines.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_taxi_ranks",
-    "Gets taxi ranks near a given stop point (station).",
-    {
-      stopPointId: z.string().describe("Stop point Naptan ID"),
-    },
-    {
-      title: "StopPoint Taxi Ranks",
-      readOnlyHint: true,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-    async ({ stopPointId }) => {
-      const result = await runtime.runPromiseExit(
-        Effect.gen(function* () {
-          const client = yield* TflClient;
-          const data = yield* client.request<
-            Array<{
-              id?: string;
-              commonName?: string;
-              placeType?: string;
-              lat?: number;
-              lon?: number;
-            }>
-          >(`/StopPoint/${encodeURIComponent(stopPointId)}/TaxiRanks`);
-          if (!data.length) return `No taxi ranks found near stop ${stopPointId}.`;
-          const lines = data.map(
-            (t) =>
-              `${t.commonName ?? t.id ?? "?"} (${t.placeType ?? "TaxiRank"}) — ${t.lat != null ? `${t.lat}, ${t.lon}` : "no coords"}`,
-          );
-          return `Taxi ranks near stop ${stopPointId} (${data.length}):\n\n${lines.join("\n")}`;
-        }),
-      );
-      if (result._tag === "Failure") return formatError(result.cause);
-      return formatSuccess(result.value);
-    },
-  );
-
-  server.tool(
-    "stoppoint_place_types",
-    "Gets places of given types that are associated with (near) a specific stop point.",
+    "stoppoint_places",
+    "Gets places associated with a stop point: car parks, taxi ranks, or other place types. Default returns all place types.",
     {
       id: z.string().describe("Stop point Naptan ID"),
+      type: z
+        .enum(["CarParks", "TaxiRanks", "placeTypes"])
+        .optional()
+        .describe(
+          "Type of associated places: 'CarParks', 'TaxiRanks', or 'placeTypes' (default). Default returns place types.",
+        ),
       placeTypes: z
         .string()
-        .describe("Comma-separated place types to look up (e.g. 'AirportTerminal,CarPark')"),
+        .optional()
+        .describe(
+          "Comma-separated place types to look up (e.g. 'AirportTerminal,CarPark'). Used when type is 'placeTypes'.",
+        ),
     },
     {
-      title: "StopPoint Place Types",
+      title: "StopPoint Places",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: true,
     },
-    async ({ id, placeTypes }) => {
+    async ({ id, type, placeTypes }) => {
       const result = await runtime.runPromiseExit(
         Effect.gen(function* () {
           const client = yield* TflClient;
+          if (type === "CarParks") {
+            const data = yield* client.request<
+              Array<{
+                id?: string;
+                name?: string;
+                carParkId?: string;
+                accessPoints?: Array<{ name?: string }>;
+                facilities?: Array<{
+                  name?: string;
+                  description?: string;
+                  paymentMethods?: string;
+                }>;
+              }>
+            >(`/StopPoint/${encodeURIComponent(id)}/CarParks`);
+            if (!data.length) return `No car parks found near stop ${id}.`;
+            const lines = data.map((cp) => {
+              const cpId = cp.carParkId ?? cp.id ?? "?";
+              const name = cp.name ?? cpId;
+              const spaces =
+                cp.facilities?.map((f) => `${f.name ?? "?"}: ${f.description ?? "?"}`).join(", ") ??
+                "details unavailable";
+              return `${name} (${cpId}) — ${spaces}`;
+            });
+            return `Car parks near stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
+          }
+          if (type === "TaxiRanks") {
+            const data = yield* client.request<
+              Array<{
+                id?: string;
+                commonName?: string;
+                placeType?: string;
+                lat?: number;
+                lon?: number;
+              }>
+            >(`/StopPoint/${encodeURIComponent(id)}/TaxiRanks`);
+            if (!data.length) return `No taxi ranks found near stop ${id}.`;
+            const lines = data.map(
+              (t) =>
+                `${t.commonName ?? t.id ?? "?"} (${t.placeType ?? "TaxiRank"}) — ${t.lat != null ? `${t.lat}, ${t.lon}` : "no coords"}`,
+            );
+            return `Taxi ranks near stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
+          }
           const data = yield* client.request<
             Array<{
               id?: string;
@@ -877,12 +716,13 @@ export const registerStopPointTools = (
               lon?: number;
             }>
           >(`/StopPoint/${encodeURIComponent(id)}/placeTypes`, { placeTypes });
-          if (!data.length) return `No places of type "${placeTypes}" found at stop ${id}.`;
+          if (!data.length)
+            return `No places${placeTypes ? ` of type "${placeTypes}"` : ""} found at stop ${id}.`;
           const lines = data.map(
             (p) =>
               `${p.commonName ?? p.id ?? "?"} (${p.placeType ?? "?"}) — ${p.lat != null ? `${p.lat}, ${p.lon}` : "no coords"}`,
           );
-          return `Places of type "${placeTypes}" at stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
+          return `Places${placeTypes ? ` of type "${placeTypes}"` : ""} at stop ${id} (${data.length}):\n\n${lines.join("\n")}`;
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);


### PR DESCRIPTION
## Summary

Implements #32 — consolidates the MCP from 74 tools down to 41 by:

- **Removing 15 meta tools** (zero-parameter tools returning static data): `line_meta_modes`, `line_meta_severity`, `line_meta_disruption_categories`, `line_meta_service_types`, `stoppoint_meta_modes`, `stoppoint_meta_stop_types`, `stoppoint_meta_categories`, `place_meta_types`, `road_meta_categories`, `road_meta_severities`, `mode_active_service_types`, `search_meta_categories`, `search_meta_providers`, `search_meta_sorts`, `journey_modes`. Valid values are now documented inline in the relevant parameter .describe() strings.
- **Merging line tool variants**: line_lookup (was line_by_ids + line_by_mode), line_status (was 4 tools), line_disruptions (was 2), line_routes (was 3)
- **Merging stop-point variants**: stoppoint_lookup (was stoppoint_by_mode + stoppoint_by_type), stoppoint_arrivals (was 2), stoppoint_disruptions (was 2), stoppoint_places (was 3: car parks + taxi ranks + place types)
- **Merging road variants**: road_lookup (was road_all + road_by_ids), road_disruptions (was 2)
- **Merging occupancy variants**: occupancy_car_parks (was 2), occupancy_charge_connectors (was 2)
- **Merging search tools**: search with optional scope param replaces search + search_bus_schedules
- **Bike point**: bike_points_all removed, bike_point_search query made optional (omit to get all ~800 bike points)
- Bumps version to 1.4.0

## Test plan

- [x] bun test passes (19 tests)
- [x] bun run lint passes (biome check clean)
- [x] tsc -p tsconfig.check.json passes (typecheck clean)
- [x] bun build passes
- [x] Tool count: 41 (down from 74)

Generated with Claude Code