### PR TITLE
feat(vehicle): add vehicle_ulez_compliance tool

### DIFF
--- a/src/domain/tools.test.ts
+++ b/src/domain/tools.test.ts
@@ -99,6 +99,35 @@ describe("bike point tools data", () => {
   });
 });
 
+describe("vehicle tools data", () => {
+  it("vehicle ulez compliance returns compliance status", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* TflClient;
+        return yield* client.request<
+          Array<{ vrm?: string; make?: string; model?: string; compliance?: string }>
+        >("/Vehicle/UlezCompliance", { vrm: "AB12CDE" });
+      }).pipe(Effect.provide(TflClientTest)),
+    );
+    expect(result[0]?.vrm).toBe("AB12CDE");
+    expect(result[0]?.compliance).toBe("Compliant");
+  });
+
+  it("vehicle emission surcharge returns ulez and caz flags", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* TflClient;
+        return yield* client.request<
+          Array<{ vrm?: string; isUlezCompliant?: boolean; isCazCompliant?: boolean }>
+        >("/Vehicle/EmissionSurcharge", { vrm: "AB12CDE" });
+      }).pipe(Effect.provide(TflClientTest)),
+    );
+    expect(result[0]?.vrm).toBe("AB12CDE");
+    expect(result[0]?.isUlezCompliant).toBe(true);
+    expect(result[0]?.isCazCompliant).toBe(true);
+  });
+});
+
 describe("custom fixture handlers", () => {
   it("can provide specific line status fixture", async () => {
     const fixtures = new Map<string, unknown>([

--- a/src/infra/TflClientTest.ts
+++ b/src/infra/TflClientTest.ts
@@ -34,5 +34,34 @@ export const TflClientTest = makeTflClientTest(
     ["/StopPoint/Meta/StopTypes", ["NaptanMetroStation"]],
     ["/Search", { matches: [] }],
     ["/Occupancy/CarPark", []],
+    [
+      "/Vehicle/UlezCompliance",
+      [
+        {
+          vrm: "AB12CDE",
+          type: "Car",
+          make: "TOYOTA",
+          model: "YARIS",
+          colour: "BLUE",
+          compliance: "Compliant",
+        },
+      ],
+    ],
+    [
+      "/Vehicle/EmissionSurcharge",
+      [
+        {
+          vrm: "AB12CDE",
+          type: "Car",
+          make: "TOYOTA",
+          model: "YARIS",
+          colour: "BLUE",
+          compliant: "Compliant",
+          isCazCompliant: true,
+          isUlezCompliant: true,
+          charges: [],
+        },
+      ],
+    ],
   ]),
 );

--- a/src/mcp/tools/vehicle.ts
+++ b/src/mcp/tools/vehicle.ts
@@ -24,6 +24,15 @@ type VehicleCompliance = {
   message?: string;
 };
 
+type VehicleUlezCompliance = {
+  vrm?: string;
+  type?: string;
+  make?: string;
+  model?: string;
+  colour?: string;
+  compliance?: string;
+};
+
 type VehicleArrival = {
   vehicleId?: string;
   lineName?: string;
@@ -56,6 +65,15 @@ const formatCompliance = (v: VehicleCompliance): string => {
   return lines.filter(Boolean).join("\n");
 };
 
+const formatUlezCompliance = (v: VehicleUlezCompliance): string =>
+  [
+    `VRM: ${v.vrm ?? "?"}`,
+    `Make/Model: ${v.make ?? "?"} ${v.model ?? ""}`.trim(),
+    `Type: ${v.type ?? "?"}`,
+    `Colour: ${v.colour ?? "?"}`,
+    `ULEZ Compliance: ${v.compliance ?? "?"}`,
+  ].join("\n");
+
 export const registerVehicleTools = (
   server: McpServer,
   runtime: ManagedRuntime.ManagedRuntime<TflClient, TflError | TflDisambiguationError>,
@@ -84,6 +102,37 @@ export const registerVehicleTools = (
           });
           if (!data.length) return `No emission surcharge data found for VRM: ${vrm}`;
           return data.map((v) => formatCompliance(v)).join("\n\n");
+        }),
+      );
+      if (result._tag === "Failure") return formatError(result.cause);
+      return formatSuccess(result.value);
+    },
+  );
+
+  server.tool(
+    "vehicle_ulez_compliance",
+    "Checks ULEZ (Ultra Low Emission Zone) compliance for a vehicle by registration. Returns the vehicle details and a simple compliance status string indicating whether the vehicle must pay the ULEZ charge.",
+    {
+      vrm: z
+        .string()
+        .describe("Vehicle Registration Mark (number plate) to check (e.g. 'AB12CDE')"),
+    },
+    {
+      title: "Vehicle ULEZ Compliance",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    async ({ vrm }) => {
+      const result = await runtime.runPromiseExit(
+        Effect.gen(function* () {
+          const client = yield* TflClient;
+          const data = yield* client.request<VehicleUlezCompliance[]>("/Vehicle/UlezCompliance", {
+            vrm,
+          });
+          if (!data.length) return `No ULEZ compliance data found for VRM: ${vrm}`;
+          return data.map((v) => formatUlezCompliance(v)).join("\n\n");
         }),
       );
       if (result._tag === "Failure") return formatError(result.cause);


### PR DESCRIPTION
## Summary

- Implements the missing `vehicle_ulez_compliance` tool that was advertised in the MCP tool list but not registered in source
- Calls the distinct TfL `/Vehicle/UlezCompliance` endpoint, which returns a simpler compliance status string (`compliance` field) — different response shape from `/Vehicle/EmissionSurcharge` (which returns full charges breakdown with `isUlezCompliant`/`isCazCompliant` flags)
- Adds `VehicleUlezCompliance` type, `formatUlezCompliance` formatter, and the tool registration following the exact same pattern as existing vehicle tools

## Test plan

- [ ] `bun test` — 21 tests pass (2 new vehicle tests added)
- [ ] `bun run typecheck` — no type errors
- [ ] `bun run lint` — no lint errors
- [ ] `vehicle_ulez_compliance` tool now appears and can be called with a real VRM

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)